### PR TITLE
Fix type mismatch in removeChat function

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -51,7 +51,11 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
 
   const uid = await kv.hget<string>(`chat:${id}`, 'userId')
 
-  if (uid !== session?.user?.id) {
+  // Convert both IDs to strings before comparing
+  // This is necessary because the session user ID is a string, while the chat user ID is a number
+  // The strict inequality check (!==) in JavaScript checks both value and type, so it would fail if the types are different
+  // By converting both IDs to strings, we ensure that the comparison is done between two strings, and it will work correctly even if the IDs are originally of different types
+  if (String(uid) !== String(session?.user?.id)) {
     return {
       error: 'Unauthorized'
     }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -51,11 +51,7 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
 
   const uid = await kv.hget<string>(`chat:${id}`, 'userId')
 
-  // Convert both IDs to strings before comparing
-  // This is necessary because the session user ID is a string, while the chat user ID is a number
-  // The strict inequality check (!==) in JavaScript checks both value and type, so it would fail if the types are different
-  // By converting both IDs to strings, we ensure that the comparison is done between two strings, and it will work correctly even if the IDs are originally of different types
-  if (String(uid) !== String(session?.user?.id)) {
+  if (uid !== session?.user?.id) {
     return {
       error: 'Unauthorized'
     }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -49,7 +49,8 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
     }
   }
 
-  const uid = await kv.hget<string>(`chat:${id}`, 'userId')
+  //Convert uid to string for consistent comparison with session.user.id
+  const uid = String(await kv.hget(`chat:${id}`, 'userId'))
 
   if (uid !== session?.user?.id) {
     return {

--- a/auth.ts
+++ b/auth.ts
@@ -25,7 +25,7 @@ export const {
     },
     session: ({ session, token }) => {
       if (session?.user && token?.id) {
-        session.user.id = String(token.id)
+        session.user.id = String(token.id); // Convert token.id to a string
       }
       return session
     },

--- a/auth.ts
+++ b/auth.ts
@@ -18,7 +18,7 @@ export const {
   callbacks: {
     jwt({ token, profile }) {
       if (profile) {
-        token.id = profile.id
+        token.id = String(profile.id); // Convert profile.id to a string
         token.image = profile.avatar_url || profile.picture
       }
       return token

--- a/auth.ts
+++ b/auth.ts
@@ -18,14 +18,14 @@ export const {
   callbacks: {
     jwt({ token, profile }) {
       if (profile) {
-        token.id = String(profile.id); // Convert profile.id to a string
+        token.id = profile.id
         token.image = profile.avatar_url || profile.picture
       }
       return token
     },
     session: ({ session, token }) => {
       if (session?.user && token?.id) {
-        session.user.id = String(token.id); // Convert token.id to a string
+        session.user.id = String(token.id)
       }
       return session
     },


### PR DESCRIPTION
This pull request addresses an issue in the removeChat function where an 'Unauthorized' error was being incorrectly thrown. The problem was due to a type mismatch during the user ID comparison.

In the existing code, the user ID from the session (a string) was being compared to the user ID from the chat (a number). This strict inequality check would fail due to the different types, even if the user IDs were the same.

The fix involves converting both IDs to strings before comparing them. This ensures that the comparison is done between two strings, and it will work correctly even if the IDs are originally of different types.

With this fix, the 'Unauthorized' error will only be thrown when it should be, i.e., when the user ID of the session does not match the user ID of the chat.