### PR TITLE
prevent scrolling to top on chat creation

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -52,7 +52,7 @@ export function Chat({ id, initialMessages, className }: ChatProps) {
       },
       onFinish() {
         if (!path.includes('chat')) {
-          router.push(`/chat/${id}`, { shallow: true })
+          router.push(`/chat/${id}`, { shallow: true, scroll: false })
           router.refresh()
         }
       }


### PR DESCRIPTION
Disable default scroll behavior in router.push() when creating a new chat.