### PR TITLE
Fix `removeChat()` action

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -51,7 +51,7 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
 
   const uid = await kv.hget<string>(`chat:${id}`, 'userId')
 
-  if (uid !== session?.user?.id) {
+  if (uid != session?.user?.id) {
     return {
       error: 'Unauthorized'
     }


### PR DESCRIPTION
`uid` will be a Number, while `session.user.id` a String.
If we perform the check with `!==` it always returns false and "throws" an unauthorized error at the user.

This tiny change allows the users to remove their chats. 