### PR TITLE
Fix removeChat, stop always returning UNAUTHORIZED

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -51,7 +51,8 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
 
   const uid = await kv.hget<string>(`chat:${id}`, 'userId')
 
-  if (uid != session?.user?.id) {
+  if (!uid) return { error: 'No user' }
+  if (String(uid) !== session?.user?.id) {
     return {
       error: 'Unauthorized'
     }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -51,7 +51,7 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
 
   const uid = await kv.hget<string>(`chat:${id}`, 'userId')
 
-  if (uid !== session?.user?.id) {
+  if (uid != session?.user?.id) {
     return {
       error: 'Unauthorized'
     }


### PR DESCRIPTION
Found this fix in https://github.com/vercel/ai-chatbot/issues/199 and confirmed it locally.