### PR TITLE
fix: Tooltip focusing error when sidebar is opened.

### DIFF
--- a/components/sidebar-mobile.tsx
+++ b/components/sidebar-mobile.tsx
@@ -20,7 +20,10 @@ export function SidebarMobile({ children }: SidebarMobileProps) {
           <span className="sr-only">Toggle Sidebar</span>
         </Button>
       </SheetTrigger>
-      <SheetContent className="inset-y-0 flex h-auto w-[300px] flex-col p-0">
+      <SheetContent
+        className="inset-y-0 flex h-auto w-[300px] flex-col p-0"
+        onOpenAutoFocus={e => e.preventDefault()}
+      >
         <Sidebar className="flex">{children}</Sidebar>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
Tooltip focusing error when sidebar is opened. #94

Before: 
![2024-01-26_17-57-31](https://github.com/vercel/ai-chatbot/assets/88022434/bb9ffea5-bddb-441f-b6b5-95aa2dc1c235)

After:
![2024-01-26_17-58-05](https://github.com/vercel/ai-chatbot/assets/88022434/4b15c10c-e76a-4135-b38d-26c2791a527a)
