### PR TITLE
refresh after clearing all chats

### DIFF
--- a/components/clear-history.tsx
+++ b/components/clear-history.tsx
@@ -63,6 +63,7 @@ export function ClearHistory({
 
                   setOpen(false)
                   router.push('/')
+                  router.refresh()
                 })
               })
             }}


### PR DESCRIPTION
Clicking on clear history at the bottom of the sidebar, does not refresh the sidebar.