### PR TITLE
Fix SQL syntax error

### DIFF
--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -7,7 +7,7 @@ async function seedUsers(client) {
       CREATE TABLE IF NOT EXISTS users (
         id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
         email TEXT NOT NULL UNIQUE,
-        password TEXT NOT NULL
+        password TEXT NOT NULL,
         salt TEXT NOT NULL
       );
     `


### PR DESCRIPTION
I failed to run `pnpm seed` due to this syntax error

```
> node -r dotenv/config ./scripts/seed.mjs

Error seeding users: error: syntax error at or near "salt"
```