### PR TITLE
fix crash when cloning locally

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,9 @@ import { Header } from '@/components/header'
 import { Toaster } from '@/components/ui/sonner'
 
 export const metadata = {
-  metadataBase: new URL(`https://${process.env.VERCEL_URL}`),
+  metadataBase: process.env.VERCEL_URL
+    ? new URL(`https://${process.env.VERCEL_URL}`)
+    : undefined,
   title: {
     default: 'Next.js AI Chatbot',
     template: `%s - Next.js AI Chatbot`


### PR DESCRIPTION
The template crashes when cloning, even after `vc env pull`, since `VERCEL_URL` is set to an empty string when pulling env var.

1. Deploy https://vercel.com/templates/next.js/nextjs-ai-chatbot 
1. Clone the repo locally 
1. vc link
1. vc env pull
1. pnpm i
1. pnpm dev

<img width="1624" alt="image" src="https://github.com/vercel/ai-chatbot/assets/1765075/bda3604f-920f-4b9a-a839-d5f630bfa6f0">
