### PR TITLE
refactor: Update import path for getMissingKeys

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -3,7 +3,7 @@ import { Chat } from '@/components/chat'
 import { AI } from '@/lib/chat/actions'
 import { auth } from '@/auth'
 import { Session } from '@/lib/types'
-import { getMissingKeys } from '../actions'
+import { getMissingKeys } from '@/app/actions'
 
 export const metadata = {
   title: 'Next.js AI Chatbot'


### PR DESCRIPTION
The import path for the getMissingKeys function was updated from '../actions' to '@/app/actions' to align with the project's import conventions and improve code clarity.

resolves issue #319 

before:
```
import { getMissingKeys } from '../actions'
```

after:
```
import { getMissingKeys } from '@/app/actions'
```