### PR TITLE
Fix duplicate dividers caused by tool call messages in getUIStateFrom…

### DIFF
--- a/lib/chat/actions.tsx
+++ b/lib/chat/actions.tsx
@@ -549,40 +549,56 @@ export const AI = createAI<AIState, UIState>({
 
 export const getUIStateFromAIState = (aiState: Chat) => {
   return aiState.messages
-    .filter(message => message.role !== 'system')
+    .filter((message) =>
+      message.role !== 'system' &&
+      !(message.role === 'assistant' &&
+        Array.isArray(message.content) &&
+        message.content.length === 1 &&
+        message.content[0].type === 'tool-call')
+    )
     .map((message, index) => ({
       id: `${aiState.chatId}-${index}`,
       display:
-        message.role === 'tool' ? (
-          message.content.map(tool => {
-            return tool.toolName === 'listStocks' ? (
-              <BotCard>
-                {/* TODO: Infer types based on the tool result*/}
-                {/* @ts-expect-error */}
-                <Stocks props={tool.result} />
-              </BotCard>
-            ) : tool.toolName === 'showStockPrice' ? (
-              <BotCard>
-                {/* @ts-expect-error */}
-                <Stock props={tool.result} />
-              </BotCard>
-            ) : tool.toolName === 'showStockPurchase' ? (
-              <BotCard>
-                {/* @ts-expect-error */}
-                <Purchase props={tool.result} />
-              </BotCard>
-            ) : tool.toolName === 'getEvents' ? (
-              <BotCard>
-                {/* @ts-expect-error */}
-                <Events props={tool.result} />
-              </BotCard>
-            ) : null
-          })
-        ) : message.role === 'user' ? (
-          <UserMessage>{message.content as string}</UserMessage>
-        ) : message.role === 'assistant' &&
-          typeof message.content === 'string' ? (
-          <BotMessage content={message.content} />
-        ) : null
-    }))
-}
+        message.role === 'tool'
+          ? message.content.map((tool) => {
+              switch (tool.toolName) {
+                case 'listStocks':
+                  return (
+                    <BotCard>
+                      {/* TODO: Infer types based on the tool result*/}
+                      {/* @ts-expect-error */}
+                      <Stocks props={tool.result} />
+                    </BotCard>
+                  );
+                case 'showStockPrice':
+                  return (
+                    <BotCard>
+                      {/* @ts-expect-error */}
+                      <Stock props={tool.result} />
+                    </BotCard>
+                  );
+                case 'showStockPurchase':
+                  return (
+                    <BotCard>
+                      {/* @ts-expect-error */}
+                      <Purchase props={tool.result} />
+                    </BotCard>
+                  );
+                case 'getEvents':
+                  return (
+                    <BotCard>
+                      {/* @ts-expect-error */}
+                      <Events props={tool.result} />
+                    </BotCard>
+                  );
+                default:
+                  return null;
+              }
+            })
+          : message.role === 'user'
+          ? <UserMessage>{message.content as string}</UserMessage>
+          : message.role === 'assistant' && typeof message.content === 'string'
+          ? <BotMessage content={message.content} />
+          : null,
+    }));
+};


### PR DESCRIPTION
…AIState function

Here is an image of the bug - double divider on tool call
![image](https://github.com/vercel/ai-chatbot/assets/69059597/a621020c-5b5d-4a4d-9606-797b4487de1e)

When loading message history, the current implementation of getUIStateFromAIState in ./lib/chat/actions.tsx results in duplicate dividers being rendered whenever a tool call message is present. This issue occurs due to how tool call messages are handled in the mapping logic without filtering out their assistant response counterparts.

This pull request addresses the issue by refining the mapping logic within getUIStateFromAIState. It introduces a filter to exclude assistant messages that are tool call responses, ensuring that only relevant messages are displayed without duplication.

Changes Made:

Added a filter condition to exclude assistant messages that are responses to tool calls.
Updated the mapping logic to handle message display appropriately based on role and content type.
This fix ensures a cleaner and more accurate rendering of message history, particularly when tool calls are involved, preventing unnecessary duplication of dividers.



