### PR TITLE
Fix (prettier.config.cjs): remove unsupported options

### DIFF
--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -6,29 +6,5 @@ module.exports = {
   singleQuote: true,
   arrowParens: 'avoid',
   tabWidth: 2,
-  trailingComma: 'none',
-  importOrder: [
-    '^(react/(.*)$)|^(react$)',
-    '^(next/(.*)$)|^(next$)',
-    '<THIRD_PARTY_MODULES>',
-    '',
-    '^types$',
-    '^@/types/(.*)$',
-    '^@/config/(.*)$',
-    '^@/lib/(.*)$',
-    '^@/hooks/(.*)$',
-    '^@/components/ui/(.*)$',
-    '^@/components/(.*)$',
-    '^@/registry/(.*)$',
-    '^@/styles/(.*)$',
-    '^@/app/(.*)$',
-    '',
-    '^[./]'
-  ],
-  importOrderSeparation: false,
-  importOrderSortSpecifiers: true,
-  importOrderBuiltinModulesToTop: true,
-  importOrderParserPlugins: ['typescript', 'jsx', 'decorators-legacy'],
-  importOrderMergeDuplicateImports: true,
-  importOrderCombineTypeAndValueImports: true
+  trailingComma: 'none'
 }


### PR DESCRIPTION
`@ianvs/prettier-plugin-sort-imports` was removed [here](https://github.com/vercel/ai-chatbot/commit/8ad7335971811597f93f88710371ca00433819bc), but `prettier.config.cjs` still contains `importOrder*` options.

Running `pnpm run format:write` gives out warnings:

```
[warn] Ignored unknown option { importOrder: ["^(react/(.*)$)|^(react$)", "^(next/(.*)$)|^(next$)", "<THIRD_PARTY_MODULES>", "", "^types$", "^@/types/(.*)$", "^@/config/(.*)$", "^@/lib/(.*)$", "^@/hooks/(.*)$", "^@/components/ui/(.*)$", "^@/components/(.*)$", "^@/registry/(.*)$", "^@/styles/(.*)$", "^@/app/(.*)$", "", "^[./]"] }.
[warn] Ignored unknown option { importOrderSeparation: false }.
[warn] Ignored unknown option { importOrderSortSpecifiers: true }.
[warn] Ignored unknown option { importOrderBuiltinModulesToTop: true }.
[warn] Ignored unknown option { importOrderParserPlugins: ["typescript", "jsx", "decorators-legacy"] }.
[warn] Ignored unknown option { importOrderMergeDuplicateImports: true }.
[warn] Ignored unknown option { importOrderCombineTypeAndValueImports: true }.
```

This PR removes all `importOrder*` options, so that `pnpm run format:write` runs fine, without warnings.