### PR TITLE
Check session user id before performing action

### DIFF
--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -23,8 +23,13 @@ export async function generateMetadata({
   }
 
   const chat = await getChat(params.id, session.user.id)
-  return {
-    title: chat?.title.toString().slice(0, 50) ?? 'Chat'
+
+  if (!chat || 'error' in chat) {
+    redirect('/')
+  } else {
+    return {
+      title: chat?.title.toString().slice(0, 50) ?? 'Chat'
+    }
   }
 }
 
@@ -39,22 +44,22 @@ export default async function ChatPage({ params }: ChatPageProps) {
   const userId = session.user.id as string
   const chat = await getChat(params.id, userId)
 
-  if (!chat) {
+  if (!chat || 'error' in chat) {
     redirect('/')
-  }
+  } else {
+    if (chat?.userId !== session?.user?.id) {
+      notFound()
+    }
 
-  if (chat?.userId !== session?.user?.id) {
-    notFound()
+    return (
+      <AI initialAIState={{ chatId: chat.id, messages: chat.messages }}>
+        <Chat
+          id={chat.id}
+          session={session}
+          initialMessages={chat.messages}
+          missingKeys={missingKeys}
+        />
+      </AI>
+    )
   }
-
-  return (
-    <AI initialAIState={{ chatId: chat.id, messages: chat.messages }}>
-      <Chat
-        id={chat.id}
-        session={session}
-        initialMessages={chat.messages}
-        missingKeys={missingKeys}
-      />
-    </AI>
-  )
 }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -8,8 +8,16 @@ import { auth } from '@/auth'
 import { type Chat } from '@/lib/types'
 
 export async function getChats(userId?: string | null) {
+  const session = await auth()
+
   if (!userId) {
     return []
+  }
+
+  if (userId !== session?.user?.id) {
+    return {
+      error: 'Unauthorized'
+    }
   }
 
   try {
@@ -31,6 +39,14 @@ export async function getChats(userId?: string | null) {
 }
 
 export async function getChat(id: string, userId: string) {
+  const session = await auth()
+
+  if (userId !== session?.user?.id) {
+    return {
+      error: 'Unauthorized'
+    }
+  }
+
   const chat = await kv.hgetall<Chat>(`chat:${id}`)
 
   if (!chat || (userId && chat.userId !== userId)) {
@@ -49,7 +65,7 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
     }
   }
 
-  //Convert uid to string for consistent comparison with session.user.id
+  // Convert uid to string for consistent comparison with session.user.id
   const uid = String(await kv.hget(`chat:${id}`, 'userId'))
 
   if (uid !== session?.user?.id) {

--- a/components/sidebar-list.tsx
+++ b/components/sidebar-list.tsx
@@ -2,6 +2,7 @@ import { clearChats, getChats } from '@/app/actions'
 import { ClearHistory } from '@/components/clear-history'
 import { SidebarItems } from '@/components/sidebar-items'
 import { ThemeToggle } from '@/components/theme-toggle'
+import { redirect } from 'next/navigation'
 import { cache } from 'react'
 
 interface SidebarListProps {
@@ -16,23 +17,27 @@ const loadChats = cache(async (userId?: string) => {
 export async function SidebarList({ userId }: SidebarListProps) {
   const chats = await loadChats(userId)
 
-  return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="flex-1 overflow-auto">
-        {chats?.length ? (
-          <div className="space-y-2 px-2">
-            <SidebarItems chats={chats} />
-          </div>
-        ) : (
-          <div className="p-8 text-center">
-            <p className="text-sm text-muted-foreground">No chat history</p>
-          </div>
-        )}
+  if (!chats || 'error' in chats) {
+    redirect('/')
+  } else {
+    return (
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="flex-1 overflow-auto">
+          {chats?.length ? (
+            <div className="space-y-2 px-2">
+              <SidebarItems chats={chats} />
+            </div>
+          ) : (
+            <div className="p-8 text-center">
+              <p className="text-sm text-muted-foreground">No chat history</p>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center justify-between p-4">
+          <ThemeToggle />
+          <ClearHistory clearChats={clearChats} isEnabled={chats?.length > 0} />
+        </div>
       </div>
-      <div className="flex items-center justify-between p-4">
-        <ThemeToggle />
-        <ClearHistory clearChats={clearChats} isEnabled={chats?.length > 0} />
-      </div>
-    </div>
-  )
+    )
+  }
 }


### PR DESCRIPTION
Previously, `getChats` and `getChat` wasn't checking if the request's session user id matched the chats that were being fetched. This patches that behavior by adding an explicit check.