### PR TITLE
Added types for currentMessages and ChatShareDialog component

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -21,6 +21,11 @@ export interface ChatPanelProps {
   scrollToBottom: () => void
 }
 
+interface CurrentMessagesProps {
+  id?: string
+  display: React.ReactNode
+}
+
 export function ChatPanel({
   id,
   title,
@@ -74,7 +79,7 @@ export function ChatPanel({
                   index > 1 && 'hidden md:block'
                 }`}
                 onClick={async () => {
-                  setMessages(currentMessages => [
+                  setMessages((currentMessages: CurrentMessagesProps[]) => [
                     ...currentMessages,
                     {
                       id: nanoid(),
@@ -86,7 +91,7 @@ export function ChatPanel({
                     example.message
                   )
 
-                  setMessages(currentMessages => [
+                  setMessages((currentMessages: CurrentMessagesProps[]) => [
                     ...currentMessages,
                     responseMessage
                   ])

--- a/components/chat-share-dialog.tsx
+++ b/components/chat-share-dialog.tsx
@@ -18,6 +18,8 @@ import { IconSpinner } from '@/components/ui/icons'
 import { useCopyToClipboard } from '@/lib/hooks/use-copy-to-clipboard'
 
 interface ChatShareDialogProps extends DialogProps {
+  open: boolean
+  onOpenChange: (shareDialogOpen: boolean) => void
   chat: Pick<Chat, 'id' | 'title' | 'messages'>
   shareChat: (id: string) => ServerActionResult<Chat>
   onCopy: () => void


### PR DESCRIPTION
Previously, the build was failing due to a Type error: Parameter 'currentMessages' implicitly has an 'any' type. This patches the issue, appropriate props was defined and added for "currentMessages" wherever required.
Additionally, ChatShareDialogProps was updated and types for "open" and "onOpenChange" prop was added. 