### PR TITLE
…

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import type { AI } from '@/lib/chat/actions'
+
 import { cn } from '@/lib/utils'
 import { ChatList } from '@/components/chat-list'
 import { ChatPanel } from '@/components/chat-panel'
@@ -24,7 +26,7 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
   const path = usePathname()
   const [input, setInput] = useState('')
   const [messages] = useUIState()
-  const [aiState] = useAIState()
+  const [aiState] = useAIState<typeof AI>()
 
   const [_, setNewChatId] = useLocalStorage('newChatId', id)
 
@@ -39,6 +41,8 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
   useEffect(() => {
     const messagesLength = aiState.messages?.length
     if (messagesLength === 2) {
+      router.refresh()
+    } else if (messagesLength === 3 && aiState.messages[2].role === 'tool') {
       router.refresh()
     }
   }, [aiState.messages, router])

--- a/components/stocks/stock-purchase.tsx
+++ b/components/stocks/stock-purchase.tsx
@@ -63,40 +63,40 @@ export function Purchase({
 
   useEffect(() => {
     const checkPurchaseStatus = () => {
-      if (purchaseStatus === 'requires_action') {
-        // check for purchase completion
-        // Find the tool message with the matching toolCallId
-        const toolMessage = aiState.messages.find(
-          message => 
-            message.role === 'tool' && 
-            message.content.some(part => part.toolCallId === toolCallId)
-        );
+      if (purchaseStatus !== 'requires_action') {
+        return;
+      }
+      // check for purchase completion
+      // Find the tool message with the matching toolCallId
+      const toolMessage = aiState.messages.find(
+        message =>
+          message.role === 'tool' &&
+          message.content.some(part => part.toolCallId === toolCallId)
+      );
 
-        if (toolMessage) {
-          const toolMessageIndex = aiState.messages.indexOf(toolMessage);
-          // Check if the next message is a system message containing "purchased"
-          const nextMessage = aiState.messages[toolMessageIndex + 1];
-          if (
-            nextMessage?.role === 'system' &&
-            nextMessage.content.includes('purchased')
-          ) {
-            setPurchaseStatus('completed');
-          } else {
-            // Check for expiration
-            const requestedAt = toolMessage.createdAt;
-            if (!requestedAt || unixTsNow() - requestedAt > 30) {
-              setPurchaseStatus('expired');
-            }
+      if (toolMessage) {
+        const toolMessageIndex = aiState.messages.indexOf(toolMessage);
+        // Check if the next message is a system message containing "purchased"
+        const nextMessage = aiState.messages[toolMessageIndex + 1];
+        if (
+          nextMessage?.role === 'system' &&
+          nextMessage.content.includes('purchased')
+        ) {
+          setPurchaseStatus('completed');
+        } else {
+          // Check for expiration
+          const requestedAt = toolMessage.createdAt;
+          if (!requestedAt || unixTsNow() - requestedAt > 30) {
+            setPurchaseStatus('expired');
           }
         }
       }
     };
-
     checkPurchaseStatus();
 
     let intervalId: NodeJS.Timeout | null = null;
     if (purchaseStatus === 'requires_action') {
-      intervalId = setInterval(checkPurchaseStatus, 1000);
+      intervalId = setInterval(checkPurchaseStatus, 5000);
     }
 
     return () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,7 @@ import { CoreMessage } from 'ai'
 
 export type Message = CoreMessage & {
   id: string
+  createdAt?: number;
 }
 
 export interface Chat extends Record<string, any> {
@@ -39,3 +40,9 @@ export interface User extends Record<string, any> {
   password: string
   salt: string
 }
+
+export type MutableAIState<AIState> = {
+  get: () => AIState;
+  update: (newState: AIState | ((current: AIState) => AIState)) => void;
+  done: ((newState: AIState) => void) | (() => void);
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -51,8 +51,10 @@ export const formatNumber = (value: number) =>
 export const runAsyncFnWithoutBlocking = (
   fn: (...args: any) => Promise<any>
 ) => {
-  fn()
-}
+  fn().catch(error => {
+    console.error('An error occurred in the async function:', error);
+  });
+};
 
 export const sleep = (ms: number) =>
   new Promise(resolve => setTimeout(resolve, ms))
@@ -87,3 +89,5 @@ export const getMessageFromCode = (resultCode: string) => {
       return 'Logged in!'
   }
 }
+
+export const unixTsNow = () => Math.floor(Date.now() / 1000);


### PR DESCRIPTION
- Resolve race condition when `aiState.done` is called before `onSetAIState` 
- This PR prevents the UI from refreshing before the db is updated.
- As per the approach proposed by @Godrules500 in https://github.com/vercel/ai-chatbot/issues/302#issuecomment-2233485144 the `onSetAIState` callback is removed and instead an `aiStateDone` wrapper around `aiState.done` is called in place of `aiState.done`. This wrapper function waits until the chat is saved to the db before marking the aiState updates as done.
- In `chat.tsx`, the `useEffect` hook for refreshing the router contains an additional check to refresh the router if the chat contains 3 messages and the last message is a tool call. The existing check only checked for 2 messages, meaning the router was not refreshed if the first user message in a chat resulted in a tool call response.
- The `Purchase` component `status` now defaults to `requires_action`, instead of `expired`, with a `useEffect` hook added to check and update the purchase status based on  the relevant tool call message and any related system messages.
- The `toolCallId` is passed as a prop to `Purchase`. This is used to find the relevant tool call in the `aiState.messages`.
- If the message immediately following the tool call message is a system message containing the string `purchased`, then the purchase is marked as completed.
- An optional `createdAt` property is added to the `Message` interface. If the tool call message was created more than 30 seconds ago, the checkout is marked as expired. While the status remains in a `requires_action` state, an interval is set to check every 5 seconds whether the status should be `expired`.