### PR TITLE
Fix DB race condition. Refresh at then end of a completed stream.

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -26,26 +26,22 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
   const [messages] = useUIState()
   const [aiState] = useAIState()
 
-  const [_, setNewChatId] = useLocalStorage('newChatId', id)
+  const [_, setNewChatAnimationId] = useLocalStorage('newChatAnimationId', id)
 
   useEffect(() => {
     if (session?.user) {
       if (!path.includes('chat') && messages.length === 1) {
         window.history.replaceState({}, '', `/chat/${id}`)
+        setNewChatAnimationId(id)
       }
     }
-  }, [id, path, session?.user, messages])
+  }, [id, path, session?.user, messages, setNewChatAnimationId])
 
   useEffect(() => {
-    const messagesLength = aiState.messages?.length
-    if (messagesLength === 2) {
+    if (aiState.refreshKey) {
       router.refresh()
     }
-  }, [aiState.messages, router])
-
-  useEffect(() => {
-    setNewChatId(id)
-  })
+  }, [aiState.refreshKey, router])
 
   useEffect(() => {
     missingKeys.map(key => {

--- a/components/sidebar-item.tsx
+++ b/components/sidebar-item.tsx
@@ -28,8 +28,8 @@ export function SidebarItem({ index, chat, children }: SidebarItemProps) {
   const pathname = usePathname()
 
   const isActive = pathname === chat.path
-  const [newChatId, setNewChatId] = useLocalStorage('newChatId', null)
-  const shouldAnimate = index === 0 && isActive && newChatId
+  const [animationKey, setNewChatAnimationId] = useLocalStorage('newChatAnimationId', null)
+  const shouldAnimate = index === 0 && isActive && animationKey
 
   if (!chat?.id) return null
 
@@ -105,7 +105,7 @@ export function SidebarItem({ index, chat, children }: SidebarItemProps) {
                   }}
                   onAnimationComplete={() => {
                     if (index === chat.title.length - 1) {
-                      setNewChatId(null)
+                      setNewChatAnimationId(null)
                     }
                   }}
                 >

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,3 +39,9 @@ export interface User extends Record<string, any> {
   password: string
   salt: string
 }
+
+export type MutableAIState<AIState> = {
+  get: () => AIState
+  update: (newState: AIState | ((current: AIState) => AIState)) => void
+  done: ((newState: AIState) => void) | (() => void)
+}


### PR DESCRIPTION
- FIxes: https://github.com/vercel/ai-chatbot/issues/302
- Fixes: https://github.com/vercel/ai-chatbot/issues/364
- Resolve race condition when aiState.done is called before onSetAIState
- This PR prevents the UI from refreshing before the db is updated.
- A similar approach proposed by @Saran33 in https://github.com/vercel/ai-chatbot/pull/399
- Implements a token based approach to refreshing instead of the hacky message length approach. 
- Only refreshes when a new message finishes. No extra refreshes on a chat with 1 message.
- Only animate the side menu when a new chat is created and name the localStorage variable more appropriately. 

https://github.com/user-attachments/assets/2bf3d8f4-bd5e-400e-a5b0-012279bd5f83


