### PR TITLE
Infered types based on the tool result

### DIFF
--- a/components/stocks/events.tsx
+++ b/components/stocks/events.tsx
@@ -1,12 +1,7 @@
+import { GetEventProps } from '@/lib/types'
 import { format, parseISO } from 'lib/utils'
 
-interface Event {
-  date: string
-  headline: string
-  description: string
-}
-
-export function Events({ props: events }: { props: Event[] }) {
+export function Events({ events }: GetEventProps) {
   return (
     <div className="-mt-2 flex w-full flex-col gap-2 py-4">
       {events.map(event => (

--- a/components/stocks/stock-purchase.tsx
+++ b/components/stocks/stock-purchase.tsx
@@ -5,19 +5,10 @@ import { useActions, useAIState, useUIState } from 'ai/rsc'
 import { formatNumber } from '@/lib/utils'
 
 import type { AI } from '@/lib/chat/actions'
+import { PurchaseProps } from '@/lib/types'
 
-interface Purchase {
-  numberOfShares?: number
-  symbol: string
-  price: number
-  status: 'requires_action' | 'completed' | 'expired'
-}
 
-export function Purchase({
-  props: { numberOfShares, symbol, price, status = 'expired' }
-}: {
-  props: Purchase
-}) {
+export function Purchase({ numberOfShares, symbol, price, status = 'expired' }: PurchaseProps) {
   const [value, setValue] = useState(numberOfShares || 100)
   const [purchasingUI, setPurchasingUI] = useState<null | React.ReactNode>(null)
   const [aiState, setAIState] = useAIState<typeof AI>()

--- a/components/stocks/stock.tsx
+++ b/components/stocks/stock.tsx
@@ -3,12 +3,8 @@
 import { useState, useRef, useEffect, useId } from 'react'
 import { subMonths, format } from 'lib/utils'
 import { useAIState } from 'ai/rsc'
+import { ShowStockPriceProps } from '@/lib/types'
 
-interface Stock {
-  symbol: string
-  price: number
-  delta: number
-}
 
 function scaleLinear(domain: [number, number], range: [number, number]) {
   const [d0, d1] = domain
@@ -47,7 +43,7 @@ function useResizeObserver<T extends HTMLElement = HTMLElement>(
   return size
 }
 
-export function Stock({ props: { symbol, price, delta } }: { props: Stock }) {
+export function Stock({ symbol, price, delta }: ShowStockPriceProps ) {
   const [aiState, setAIState] = useAIState()
   const id = useId()
 

--- a/components/stocks/stocks.tsx
+++ b/components/stocks/stocks.tsx
@@ -3,14 +3,8 @@
 import { useActions, useUIState } from 'ai/rsc'
 
 import type { AI } from '@/lib/chat/actions'
-
-interface Stock {
-  symbol: string
-  price: number
-  delta: number
-}
-
-export function Stocks({ props: stocks }: { props: Stock[] }) {
+import { ListStockProps } from '@/lib/types'
+export function Stocks({ stocks }: ListStockProps) {
   const [, setMessages] = useUIState<typeof AI>()
   const { submitUserMessage } = useActions()
 
@@ -27,9 +21,8 @@ export function Stocks({ props: stocks }: { props: Stock[] }) {
             }}
           >
             <div
-              className={`text-xl ${
-                stock.delta > 0 ? 'text-green-600' : 'text-red-600'
-              } flex w-11 flex-row justify-center rounded-md bg-white/10 p-2`}
+              className={`text-xl ${stock.delta > 0 ? 'text-green-600' : 'text-red-600'
+                } flex w-11 flex-row justify-center rounded-md bg-white/10 p-2`}
             >
               {stock.delta > 0 ? '↑' : '↓'}
             </div>
@@ -41,16 +34,14 @@ export function Stocks({ props: stocks }: { props: Stock[] }) {
             </div>
             <div className="ml-auto flex flex-col">
               <div
-                className={`${
-                  stock.delta > 0 ? 'text-green-600' : 'text-red-600'
-                } bold text-right uppercase`}
+                className={`${stock.delta > 0 ? 'text-green-600' : 'text-red-600'
+                  } bold text-right uppercase`}
               >
                 {` ${((stock.delta / stock.price) * 100).toExponential(1)}%`}
               </div>
               <div
-                className={`${
-                  stock.delta > 0 ? 'text-green-700' : 'text-red-700'
-                } text-right text-base`}
+                className={`${stock.delta > 0 ? 'text-green-700' : 'text-red-700'
+                  } text-right text-base`}
               >
                 {stock.delta.toExponential(1)}
               </div>

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -1,0 +1,46 @@
+import { z } from "zod"
+const getEventsSchema = z.object({
+    events: z.array(
+        z.object({
+            date: z
+                .string()
+                .describe('The date of the event, in ISO-8601 format'),
+            headline: z.string().describe('The headline of the event'),
+            description: z.string().describe('The description of the event')
+        })
+    )
+})
+
+const showStockPurchaseSchema = z.object({
+    symbol: z
+        .string()
+        .describe(
+            'The name or symbol of the stock or currency. e.g. DOGE/AAPL/USD.'
+        ),
+    price: z.number().describe('The price of the stock.'),
+    numberOfShares: z
+        .number()
+        .optional()
+        .describe(
+            'The **number of shares** for a stock or currency to purchase. Can be optional if the user did not specify it.'
+        )
+})
+const showStockPriceSchema = z.object({
+    symbol: z
+        .string()
+        .describe(
+            'The name or symbol of the stock or currency. e.g. DOGE/AAPL/USD.'
+        ),
+    price: z.number().describe('The price of the stock.'),
+    delta: z.number().describe('The change in price of the stock')
+})
+const listStockSchema = z.object({
+    stocks: z.array(
+        z.object({
+            symbol: z.string().describe('The symbol of the stock'),
+            price: z.number().describe('The price of the stock'),
+            delta: z.number().describe('The change in price of the stock')
+        })
+    )
+})
+export { getEventsSchema, showStockPurchaseSchema, showStockPriceSchema, listStockSchema }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,6 @@
 import { CoreMessage } from 'ai'
+import { z } from 'zod'
+import { showStockPriceSchema, getEventsSchema, listStockSchema, showStockPurchaseSchema } from './schemas'
 
 export type Message = CoreMessage & {
   id: string
@@ -17,8 +19,8 @@ export interface Chat extends Record<string, any> {
 export type ServerActionResult<Result> = Promise<
   | Result
   | {
-      error: string
-    }
+    error: string
+  }
 >
 
 export interface Session {
@@ -39,3 +41,11 @@ export interface User extends Record<string, any> {
   password: string
   salt: string
 }
+export type ShowStockPriceProps = z.infer<typeof showStockPriceSchema>
+export type GetEventProps = z.infer<typeof getEventsSchema>
+export type ListStockProps = z.infer<typeof listStockSchema>
+export type ShowStockPurchaseProps = z.infer<typeof showStockPurchaseSchema>
+
+export type PurchaseProps = {
+  status: 'requires_action' | 'completed' | 'expired'
+} & ShowStockPurchaseProps


### PR DESCRIPTION
I refactored the code to infer the types based on the tool's result.
to complete this todo    ( TODO: Infer types based on the tool result )


```typescript
export const getUIStateFromAIState = (aiState: Chat) => {
  return aiState.messages
    .filter(message => message.role !== 'system')
    .map((message, index) => ({
      id: `${aiState.chatId}-${index}`,
      display:
        message.role === 'tool' ? (
          message.content.map(tool => {
            return tool.toolName === 'listStocks' ? (
              <BotCard>
                <Stocks {...tool.result as ListStockProps} />
              </BotCard>
            ) : tool.toolName === 'showStockPrice' ? (
              <BotCard>
                <Stock {...tool.result as ShowStockPriceProps} />
              </BotCard>
            ) : tool.toolName === 'showStockPurchase' ? (
              <BotCard>
                <Purchase {...tool.result as PurchaseProps} />
              </BotCard>
            ) : tool.toolName === 'getEvents' ? (
              <BotCard>
                <Events events={tool.result as GetEventProps["events"]} />
              </BotCard>
            ) : null
          })
        ) : message.role === 'user' ? (
          <UserMessage>{message.content as string}</UserMessage>
        ) : message.role === 'assistant' &&
          typeof message.content === 'string' ? (
          <BotMessage content={message.content} />
        ) : null
    }))
}
``` 