### PR TITLE
Fix markdown ul tag to use disc style

### DIFF
--- a/components/custom/markdown.tsx
+++ b/components/custom/markdown.tsx
@@ -39,7 +39,7 @@ const NonMemoizedMarkdown = ({ children }: { children: string }) => {
     },
     ul: ({ node, children, ...props }: any) => {
       return (
-        <ul className="list-decimal list-outside ml-4" {...props}>
+        <ul className="list-disc list-outside ml-4" {...props}>
           {children}
         </ul>
       );


### PR DESCRIPTION
I believe the markdown unordered list (ul) tag should be using the disc style instead of the number style.