### PR TITLE
fix: image preview on chat messages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -144,3 +144,9 @@
 .suggestion-highlight {
   @apply bg-yellow-100 hover:bg-yellow-200 dark:hover:bg-yellow-400/50 dark:text-yellow-50 dark:bg-yellow-400/40;
 }
+
+img[alt=md-image] {
+  width: 5rem;
+  margin: 0.5rem 0;
+  border-radius: 0.5rem;
+}


### PR DESCRIPTION
Fixes #475 

Ideally I would keep the array of `Attachment` on the chat history so the attachments would be rendered by the `PreviewAttachment` component, but I noticed that doing that results in a overuse of tokens. Apparently the models keep processing those attachments for every follow up message, even when the follow up user messages only has texts (I only tested this with OpenAI's models but I believe this behaviour is not model-specific).

So this approach appends a markdown by the end of the text to render the images, and a new CSS class on `globals.css` makes it a little nicer.

Before:
<img width="450" alt="Screenshot 2024-11-04 at 18 33 53" src="https://github.com/user-attachments/assets/d98dbc1a-b5ef-4f02-b3e0-aa3de72a404f">

After:
<img width="450" alt="Screenshot 2024-11-04 at 18 32 50" src="https://github.com/user-attachments/assets/e8276cb4-0226-4493-91e7-7caffe81ff81">

If the image is tall:
<img width="450" alt="Screenshot 2024-11-04 at 18 38 32" src="https://github.com/user-attachments/assets/1fcd3529-0a76-4fbd-bbe2-dc4a523f1606">

Multiple images:
<img width="450" alt="Screenshot 2024-11-04 at 18 47 19" src="https://github.com/user-attachments/assets/cfdfcf2b-a680-48f8-bb23-5763cee85758">
