### PR TITLE
Use className in Sidebar Toggle

### DIFF
--- a/components/custom/sidebar-toggle.tsx
+++ b/components/custom/sidebar-toggle.tsx
@@ -17,7 +17,7 @@ export function SidebarToggle({
       <Button
         onClick={toggleSidebar}
         variant="ghost"
-        className="md:px-2 md:h-fit"
+        className={cn('md:px-2 md:h-fit', className)}
       >
         <SidebarLeftIcon />
       </Button>


### PR DESCRIPTION
`cn` and `className` was unused previously