### PR TITLE
feat(preview-attachments): Now supports other file types previews in chat

### DIFF
--- a/components/preview-attachment.tsx
+++ b/components/preview-attachment.tsx
@@ -1,5 +1,4 @@
 import type { Attachment } from 'ai';
-
 import { LoaderIcon } from './icons';
 
 export const PreviewAttachment = ({
@@ -11,24 +10,60 @@ export const PreviewAttachment = ({
 }) => {
   const { name, url, contentType } = attachment;
 
+  // Helper function to get file type label and styles
+  const getFileTypeRepresentation = (contentType: string | undefined) => {
+    if (!contentType) return { label: 'Unknown', bgClass: 'bg-gray-300' };
+
+    if (contentType.startsWith('image')) return null; // For images, show actual preview
+
+    const typeMap: Record<string, { label: string; bgClass: string }> = {
+      'application/pdf': { label: 'PDF', bgClass: 'bg-red-500' },
+      'application/msword': { label: 'DOC', bgClass: 'bg-blue-500' },
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document': { label: 'DOCX', bgClass: 'bg-blue-500' },
+      'application/vnd.ms-excel': { label: 'XLS', bgClass: 'bg-green-500' },
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': { label: 'XLSX', bgClass: 'bg-green-500' },
+      'application/vnd.ms-powerpoint': { label: 'PPT', bgClass: 'bg-orange-500' },
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation': { label: 'PPTX', bgClass: 'bg-orange-500' },
+      'application/zip': { label: 'ZIP', bgClass: 'bg-yellow-500' },
+      'application/x-rar-compressed': { label: 'RAR', bgClass: 'bg-yellow-500' },
+      'audio/mpeg': { label: 'MP3', bgClass: 'bg-purple-500' },
+      'audio/wav': { label: 'WAV', bgClass: 'bg-purple-500' },
+      'video/mp4': { label: 'MP4', bgClass: 'bg-pink-500' },
+      'video/x-msvideo': { label: 'AVI', bgClass: 'bg-pink-500' },
+      'text/plain': { label: 'TXT', bgClass: 'bg-gray-500' },
+      'text/csv': { label: 'CSV', bgClass: 'bg-teal-500' },
+    };
+
+    return (
+      typeMap[contentType] || {
+        label: contentType.split('/')[1]?.toUpperCase() || 'File',
+        bgClass: 'bg-gray-400',
+      }
+    );
+  };
+
+  const fileType = getFileTypeRepresentation(contentType);
+
   return (
     <div className="flex flex-col gap-2">
-      <div className="w-20 aspect-video bg-muted rounded-md relative flex flex-col items-center justify-center">
-        {contentType ? (
-          contentType.startsWith('image') ? (
-            // NOTE: it is recommended to use next/image for images
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              key={url}
-              src={url}
-              alt={name ?? 'An image attachment'}
-              className="rounded-md size-full object-cover"
-            />
-          ) : (
-            <div className="" />
-          )
+      <div className="w-20 aspect-video bg-muted rounded-md relative flex items-center justify-center">
+        {contentType && contentType.startsWith('image') ? (
+          // For images, show the actual preview
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            key={url}
+            src={url}
+            alt={name ?? 'An image attachment'}
+            className="rounded-md size-full object-cover"
+          />
         ) : (
-          <div className="" />
+          fileType && (
+            <div
+              className={`w-full h-full flex items-center justify-center rounded-md text-white text-sm font-medium ${fileType.bgClass}`}
+            >
+              {fileType.label}
+            </div>
+          )
         )}
 
         {isUploading && (


### PR DESCRIPTION
This PR adds support to the preview attachments. Earlier ONLY IMAGES were being previewed in the chat before sending to the chatbot and other file types like pdf, docx etc., were seen blank. Now other file types will have a preview which simply displays the respective file type of attachment.

This feature provides feasibility to the user to check the prompt once again before sending and can be further modified for much added accessibility.