### PR TITLE
fix: hydration error on small device (chat-header)

### DIFF
--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { useWindowSize } from 'usehooks-ts';
 
 import { ModelSelector } from '@/components/model-selector';
@@ -14,8 +15,24 @@ import { useSidebar } from './ui/sidebar';
 export function ChatHeader({ selectedModelId }: { selectedModelId: string }) {
   const router = useRouter();
   const { open } = useSidebar();
-
+  const [mounted, setMounted] = useState(false);
   const { width: windowWidth } = useWindowSize();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2">
+        <SidebarToggle />
+        <ModelSelector
+          selectedModelId={selectedModelId}
+          className="order-1 md:order-2"
+        />
+      </header>
+    );
+  }
 
   return (
     <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2">


### PR DESCRIPTION
Issue & Resolution Note for Vercel AI Chat Repo
Issue:#535

The chat app encountered a hydration mismatch error due to the use of the useWindowSize hook. This occurred because server-side rendered content couldn’t access the window dimensions, causing a mismatch when the client-side rendered content based on the actual window width.

Resolution:

To fix this, we added a client-side mounting check using an isMounted state tracker:

Initially rendered a simplified header that matched the SSR output.
After the client was mounted, we rendered the full header with width-dependent content.
This ensures consistent rendering between server and client, following React’s SSR best practices.

Fixed Component: components/chat-header.tsx
<img width="1680" alt="error-vercel-chat" src="https://github.com/user-attachments/assets/44c0f836-80aa-464f-bbf1-1f8ff92307e0">

