### PR TITLE
chore: fix typo in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ AUTH_SECRET=****
 # The following keys below are automatically created and
 # added to your environment when you deploy on vercel
 
-# Instructions to create kv database here: https://vercel.com/docs/storage/vercel-blob
+# Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob
 BLOB_READ_WRITE_TOKEN=****
 
 # Instructions to create a database here: https://vercel.com/docs/storage/vercel-postgres/quickstart


### PR DESCRIPTION
change kv database to Vercel Blob Store