### PR TITLE
Fix matcher for chat/[id] route in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,5 +5,5 @@ import { authConfig } from '@/app/(auth)/auth.config';
 export default NextAuth(authConfig).auth;
 
 export const config = {
-  matcher: ['/', '/:id', '/api/:path*', '/login', '/register'],
+  matcher: ['/', '/chat/:id', '/api/:path*', '/login', '/register'],
 };


### PR DESCRIPTION
Hi,

The middleware does not intercept the /chat/[id] route in the matcher config: `/:id` vs `/chat/:id`

So there is no session verification.