### PR TITLE
fix: lint command is passive and throws errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbo",
     "build": "tsx lib/db/migrate && next build",
     "start": "next start",
-    "lint": "next lint && biome lint --write --unsafe",
+    "lint": "next lint && biome lint",
     "lint:fix": "next lint --fix && biome lint --write --unsafe",
     "format": "biome format --write",
     "db:generate": "drizzle-kit generate",


### PR DESCRIPTION
During the ghactions checks, `pnpm lint` is run, but the issue is that this was running the fix option for biome, and so was not reporting any errors.

This results in published code that causes our linters to complain, and so we fix the lint issues, but then when we want to merge upstream changes in, the lint errors are not fixed there, and so there is extra labour involved in resolving conflicts.