### PR TITLE
fix: unreadable inline code in user message in light mode

### DIFF
--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -12,13 +12,13 @@ const NonMemoizedMarkdown = ({ children }: { children: string }) => {
         // @ts-expect-error
         <pre
           {...props}
-          className={`${className} text-sm w-[80dvw] md:max-w-[500px] overflow-x-scroll bg-zinc-100 p-3 rounded-lg mt-2 dark:bg-zinc-800`}
+          className={`${className} text-sm w-[80dvw] md:max-w-[500px] overflow-x-scroll bg-zinc-100 p-3 rounded-lg mt-2 dark:bg-zinc-800 group-data-[role=user]/message:bg-primary-foreground/30`}
         >
           <code className={match[1]}>{children}</code>
         </pre>
       ) : (
         <code
-          className={`${className} text-sm bg-zinc-100 dark:bg-zinc-800 py-0.5 px-1 rounded-md`}
+          className={`${className} text-sm bg-zinc-100 dark:bg-zinc-800 py-0.5 px-1 rounded-md group-data-[role=user]/message:bg-primary-foreground/30`}
           {...props}
         >
           {children}


### PR DESCRIPTION
Hi,

In light mode, the inline code in the user's message is unreadable.
Fixed by adding ```bg-primary-foreground/30``` only if it's a user's message.

I'll let you adjust the color according to your preference 😊.

![message-code-inline](https://github.com/user-attachments/assets/cce2e939-1214-4547-9b81-66197b87fca1)
