### PR TITLE
fix: don't request vote api for public chat

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -70,7 +70,7 @@ export function Chat({
   });
 
   const { data: votes } = useSWR<Array<Vote>>(
-    `/api/vote?chatId=${id}`,
+    !isReadonly ? `/api/vote?chatId=${id}` : null,
     fetcher,
   );
 


### PR DESCRIPTION
Hi,

There's no need to make requests to the vote api, as they're hidden in the public chat.