### PR TITLE
fix send button logical error

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -77,7 +77,9 @@ function PureMultimodalInput({
   const adjustHeight = () => {
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = `${textareaRef.current.scrollHeight + 2}px`;
+      textareaRef.current.style.height = `${
+        textareaRef.current.scrollHeight + 2
+      }px`;
     }
   };
 
@@ -349,6 +351,6 @@ function PureSendButton({
 const SendButton = memo(PureSendButton, (prevProps, nextProps) => {
   if (prevProps.uploadQueue.length !== nextProps.uploadQueue.length)
     return false;
-  if (!prevProps.input !== !nextProps.input) return false;
+  if (prevProps.input !== nextProps.input) return false;
   return true;
 });


### PR DESCRIPTION
The memoized `sendButton` (in multimodal-input component) is not receiving the intended `input` prop update because of a logical error in the memo callback function, causing a weird behavior of sending just the first character of user's input prompt.

How to replicate this bug?
- Submit a prompt using the send button

This PR fixes the bug.
