### PR TITLE
Fix styles not being displayed in diff

### DIFF
--- a/components/block.tsx
+++ b/components/block.tsx
@@ -459,7 +459,7 @@ function PureBlock({
 
             <div
               className={cn(
-                'dark:bg-muted bg-background h-full overflow-y-scroll !max-w-full pb-40 items-center',
+                'prose dark:prose-invert dark:bg-muted bg-background h-full overflow-y-scroll !max-w-full pb-40 items-center',
                 {
                   'py-2 px-2': block.kind === 'code',
                   'py-8 md:p-20 px-4': block.kind === 'text',


### PR DESCRIPTION
This commit breaked the styles in diff mode, fixed it.

https://github.com/vercel/ai-chatbot/pull/637

<img width="839" alt="Screenshot 2024-12-20 at 12 43 35" src="https://github.com/user-attachments/assets/6d7640c9-57c3-483d-beab-7672a86eb913" />
