### PR TITLE
feat: making documents inside public chats visible

### DIFF
--- a/app/(auth)/auth.config.ts
+++ b/app/(auth)/auth.config.ts
@@ -1,5 +1,7 @@
 import type { NextAuthConfig } from 'next-auth';
 
+const publicRoutes = ['/api/document'];
+
 export const authConfig = {
   pages: {
     signIn: '/login',
@@ -15,18 +17,20 @@ export const authConfig = {
       const isOnChat = nextUrl.pathname.startsWith('/');
       const isOnRegister = nextUrl.pathname.startsWith('/register');
       const isOnLogin = nextUrl.pathname.startsWith('/login');
+      const isPublicRoute = publicRoutes.some((route) =>
+        nextUrl.pathname.startsWith(route),
+      );
 
       if (isLoggedIn && (isOnLogin || isOnRegister)) {
         return Response.redirect(new URL('/', nextUrl as unknown as URL));
       }
 
-      if (isOnRegister || isOnLogin) {
-        return true; // Always allow access to register and login pages
+      if (isOnRegister || isOnLogin || isPublicRoute) {
+        return true; // Always allow access to register and login pages or public routes
       }
 
       if (isOnChat) {
-        if (isLoggedIn) return true;
-        return false; // Redirect unauthenticated users to login page
+        return isLoggedIn; // Redirect unauthenticated users to login page
       }
 
       if (isLoggedIn) {

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -130,12 +130,12 @@ export async function POST(request: Request) {
               kind: z.enum(['text', 'code']),
             }),
             execute: async ({ title, kind }) => {
-              const id = generateUUID();
+              const documentId = generateUUID();
               let draftText = '';
 
               dataStream.writeData({
                 type: 'id',
-                content: id,
+                content: documentId,
               });
 
               dataStream.writeData({
@@ -209,16 +209,17 @@ export async function POST(request: Request) {
 
               if (session.user?.id) {
                 await saveDocument({
-                  id,
+                  id: documentId,
                   title,
                   kind,
                   content: draftText,
                   userId: session.user.id,
+                  chatId: id,
                 });
               }
 
               return {
-                id,
+                id: documentId,
                 title,
                 kind,
                 content:
@@ -234,8 +235,8 @@ export async function POST(request: Request) {
                 .string()
                 .describe('The description of changes that need to be made'),
             }),
-            execute: async ({ id, description }) => {
-              const document = await getDocumentById({ id });
+            execute: async ({ id: documentId, description }) => {
+              const document = await getDocumentById({ id: documentId });
 
               if (!document) {
                 return {
@@ -314,16 +315,17 @@ export async function POST(request: Request) {
 
               if (session.user?.id) {
                 await saveDocument({
-                  id,
+                  id: documentId,
                   title: document.title,
                   content: draftText,
                   kind: document.kind,
                   userId: session.user.id,
+                  chatId: id,
                 });
               }
 
               return {
-                id,
+                id: documentId,
                 title: document.title,
                 kind: document.kind,
                 content: 'The document has been updated successfully.',

--- a/components/block-actions.tsx
+++ b/components/block-actions.tsx
@@ -4,22 +4,24 @@ import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { useCopyToClipboard } from 'usehooks-ts';
 import { toast } from 'sonner';
-import { ConsoleOutput, UIBlock } from './block';
+import type { ConsoleOutput, UIBlock } from './block';
 import {
-  Dispatch,
+  type Dispatch,
   memo,
-  SetStateAction,
+  type SetStateAction,
   startTransition,
   useCallback,
   useState,
 } from 'react';
+
+export type BlockActionsMode = 'read-only' | 'edit' | 'diff';
 
 interface BlockActionsProps {
   block: UIBlock;
   handleVersionChange: (type: 'next' | 'prev' | 'toggle' | 'latest') => void;
   currentVersionIndex: number;
   isCurrentVersion: boolean;
-  mode: 'read-only' | 'edit' | 'diff';
+  mode: BlockActionsMode;
   setConsoleOutputs: Dispatch<SetStateAction<Array<ConsoleOutput>>>;
 }
 
@@ -131,62 +133,66 @@ function PureBlockActions({
         <RunCodeButton block={block} setConsoleOutputs={setConsoleOutputs} />
       )}
 
-      {block.kind === 'text' && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="outline"
-              className={cn(
-                'p-2 h-fit !pointer-events-auto dark:hover:bg-zinc-700',
-                {
-                  'bg-muted': mode === 'diff',
-                },
-              )}
-              onClick={() => {
-                handleVersionChange('toggle');
-              }}
-              disabled={
-                block.status === 'streaming' || currentVersionIndex === 0
-              }
-            >
-              <ClockRewind size={18} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>View changes</TooltipContent>
-        </Tooltip>
+      {mode !== 'read-only' && (
+        <>
+          {block.kind === 'text' && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  className={cn(
+                    'p-2 h-fit !pointer-events-auto dark:hover:bg-zinc-700',
+                    {
+                      'bg-muted': mode === 'diff',
+                    },
+                  )}
+                  onClick={() => {
+                    handleVersionChange('toggle');
+                  }}
+                  disabled={
+                    block.status === 'streaming' || currentVersionIndex === 0
+                  }
+                >
+                  <ClockRewind size={18} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>View changes</TooltipContent>
+            </Tooltip>
+          )}
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                className="p-2 h-fit dark:hover:bg-zinc-700 !pointer-events-auto"
+                onClick={() => {
+                  handleVersionChange('prev');
+                }}
+                disabled={currentVersionIndex === 0 || block.status === 'streaming'}
+              >
+                <UndoIcon size={18} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>View Previous version</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                className="p-2 h-fit dark:hover:bg-zinc-700 !pointer-events-auto"
+                onClick={() => {
+                  handleVersionChange('next');
+                }}
+                disabled={isCurrentVersion || block.status === 'streaming'}
+              >
+                <RedoIcon size={18} />
+              </Button>
+            </TooltipTrigger>
+              <TooltipContent>View Next version</TooltipContent>
+          </Tooltip>
+        </>
       )}
-
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="outline"
-            className="p-2 h-fit dark:hover:bg-zinc-700 !pointer-events-auto"
-            onClick={() => {
-              handleVersionChange('prev');
-            }}
-            disabled={currentVersionIndex === 0 || block.status === 'streaming'}
-          >
-            <UndoIcon size={18} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>View Previous version</TooltipContent>
-      </Tooltip>
-
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="outline"
-            className="p-2 h-fit dark:hover:bg-zinc-700 !pointer-events-auto"
-            onClick={() => {
-              handleVersionChange('next');
-            }}
-            disabled={isCurrentVersion || block.status === 'streaming'}
-          >
-            <RedoIcon size={18} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>View Next version</TooltipContent>
-      </Tooltip>
 
       <Tooltip>
         <TooltipTrigger asChild>
@@ -213,6 +219,7 @@ export const BlockActions = memo(PureBlockActions, (prevProps, nextProps) => {
   if (prevProps.currentVersionIndex !== nextProps.currentVersionIndex)
     return false;
   if (prevProps.isCurrentVersion !== nextProps.isCurrentVersion) return false;
+  if (prevProps.mode !== nextProps.mode) return false;
 
   return true;
 });

--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -6,7 +6,7 @@ import { python } from '@codemirror/lang-python';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { basicSetup } from 'codemirror';
 import React, { memo, useEffect, useRef } from 'react';
-import { Suggestion } from '@/lib/db/schema';
+import type { Suggestion } from '@/lib/db/schema';
 
 type EditorProps = {
   content: string;
@@ -15,9 +15,10 @@ type EditorProps = {
   isCurrentVersion: boolean;
   currentVersionIndex: number;
   suggestions: Array<Suggestion>;
+  isReadonly?: boolean;
 };
 
-function PureCodeEditor({ content, saveContent, status }: EditorProps) {
+function PureCodeEditor({ content, saveContent, status, isReadonly }: EditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorView | null>(null);
 
@@ -25,7 +26,13 @@ function PureCodeEditor({ content, saveContent, status }: EditorProps) {
     if (containerRef.current && !editorRef.current) {
       const startState = EditorState.create({
         doc: content,
-        extensions: [basicSetup, python(), oneDark],
+        extensions: [
+          basicSetup,
+          python(),
+          oneDark,
+          EditorView.editable.of(!isReadonly),
+          EditorState.readOnly.of(!!isReadonly)
+        ],
       });
 
       editorRef.current = new EditorView({
@@ -47,7 +54,7 @@ function PureCodeEditor({ content, saveContent, status }: EditorProps) {
   useEffect(() => {
     if (editorRef.current) {
       const updateListener = EditorView.updateListener.of((update) => {
-        if (update.docChanged) {
+        if (update.docChanged && !isReadonly) {
           const transaction = update.transactions.find(
             (tr) => !tr.annotation(Transaction.remote),
           );
@@ -61,12 +68,19 @@ function PureCodeEditor({ content, saveContent, status }: EditorProps) {
 
       const newState = EditorState.create({
         doc: editorRef.current.state.doc,
-        extensions: [basicSetup, python(), oneDark, updateListener],
+        extensions: [
+          basicSetup,
+          python(),
+          oneDark,
+          updateListener,
+          EditorView.editable.of(!isReadonly),
+          EditorState.readOnly.of(!!isReadonly)
+        ],
       });
 
       editorRef.current.setState(newState);
     }
-  }, [saveContent]);
+  }, [saveContent, isReadonly]);
 
   useEffect(() => {
     if (editorRef.current && content) {
@@ -103,6 +117,7 @@ function areEqual(prevProps: EditorProps, nextProps: EditorProps) {
   if (prevProps.status === 'streaming' && nextProps.status === 'streaming')
     return false;
   if (prevProps.content !== nextProps.content) return false;
+  if (prevProps.isReadonly !== nextProps.isReadonly) return false;
 
   return true;
 }

--- a/components/document-preview.tsx
+++ b/components/document-preview.tsx
@@ -2,16 +2,16 @@
 
 import {
   memo,
-  MouseEvent,
+  type MouseEvent,
   useCallback,
   useEffect,
   useMemo,
   useRef,
 } from 'react';
-import { UIBlock } from './block';
+import type { UIBlock } from './block';
 import { FileIcon, FullscreenIcon, LoaderIcon } from './icons';
 import { cn, fetcher } from '@/lib/utils';
-import { Document } from '@/lib/db/schema';
+import type { Document } from '@/lib/db/schema';
 import { InlineDocumentSkeleton } from './document-skeleton';
 import useSWR from 'swr';
 import { Editor } from './editor';
@@ -21,15 +21,15 @@ import { useBlock } from '@/hooks/use-block';
 import equal from 'fast-deep-equal';
 
 interface DocumentPreviewProps {
-  isReadonly: boolean;
   result?: any;
   args?: any;
+  chatId: string;
 }
 
 export function DocumentPreview({
-  isReadonly,
   result,
   args,
+  chatId,
 }: DocumentPreviewProps) {
   const { block, setBlock } = useBlock();
 
@@ -61,7 +61,7 @@ export function DocumentPreview({
         <DocumentToolResult
           type="create"
           result={{ id: result.id, title: result.title, kind: result.kind }}
-          isReadonly={isReadonly}
+          chatId={chatId}
         />
       );
     }
@@ -71,7 +71,7 @@ export function DocumentPreview({
         <DocumentToolCall
           type="create"
           args={{ title: args.title }}
-          isReadonly={isReadonly}
+          chatId={chatId}
         />
       );
     }
@@ -91,6 +91,7 @@ export function DocumentPreview({
           id: block.documentId,
           createdAt: new Date(),
           userId: 'noop',
+          chatId: block.chatId,
         }
       : null;
 
@@ -98,7 +99,12 @@ export function DocumentPreview({
 
   return (
     <div className="relative w-full cursor-pointer">
-      <HitboxLayer hitboxRef={hitboxRef} result={result} setBlock={setBlock} />
+      <HitboxLayer
+        hitboxRef={hitboxRef}
+        result={result}
+        setBlock={setBlock}
+        chatId={chatId}
+      />
       <DocumentHeader
         title={document.title}
         isStreaming={block.status === 'streaming'}
@@ -131,10 +137,12 @@ const PureHitboxLayer = ({
   hitboxRef,
   result,
   setBlock,
+  chatId,
 }: {
   hitboxRef: React.RefObject<HTMLDivElement>;
   result: any;
   setBlock: (updaterFn: UIBlock | ((currentBlock: UIBlock) => UIBlock)) => void;
+  chatId: string;
 }) => {
   const handleClick = useCallback(
     (event: MouseEvent<HTMLElement>) => {
@@ -148,6 +156,7 @@ const PureHitboxLayer = ({
               documentId: result.id,
               kind: result.kind,
               isVisible: true,
+              chatId,
               boundingBox: {
                 left: boundingBox.x,
                 top: boundingBox.y,
@@ -157,7 +166,7 @@ const PureHitboxLayer = ({
             },
       );
     },
-    [setBlock, result],
+    [setBlock, result, chatId],
   );
 
   return (

--- a/components/document.tsx
+++ b/components/document.tsx
@@ -2,7 +2,6 @@ import { memo } from 'react';
 
 import type { BlockKind } from './block';
 import { FileIcon, LoaderIcon, MessageIcon, PencilEditIcon } from './icons';
-import { toast } from 'sonner';
 import { useBlock } from '@/hooks/use-block';
 
 const getActionText = (
@@ -26,13 +25,13 @@ const getActionText = (
 interface DocumentToolResultProps {
   type: 'create' | 'update' | 'request-suggestions';
   result: { id: string; title: string; kind: BlockKind };
-  isReadonly: boolean;
+  chatId: string;
 }
 
 function PureDocumentToolResult({
   type,
   result,
-  isReadonly,
+  chatId,
 }: DocumentToolResultProps) {
   const { setBlock } = useBlock();
 
@@ -41,13 +40,6 @@ function PureDocumentToolResult({
       type="button"
       className="bg-background cursor-pointer border py-2 px-3 rounded-xl w-fit flex flex-row gap-3 items-start"
       onClick={(event) => {
-        if (isReadonly) {
-          toast.error(
-            'Viewing files in shared chats is currently not supported.',
-          );
-          return;
-        }
-
         const rect = event.currentTarget.getBoundingClientRect();
 
         const boundingBox = {
@@ -65,6 +57,7 @@ function PureDocumentToolResult({
           isVisible: true,
           status: 'idle',
           boundingBox,
+          chatId,
         });
       }}
     >
@@ -89,13 +82,13 @@ export const DocumentToolResult = memo(PureDocumentToolResult, () => true);
 interface DocumentToolCallProps {
   type: 'create' | 'update' | 'request-suggestions';
   args: { title: string };
-  isReadonly: boolean;
+  chatId: string;
 }
 
 function PureDocumentToolCall({
   type,
   args,
-  isReadonly,
+  chatId,
 }: DocumentToolCallProps) {
   const { setBlock } = useBlock();
 
@@ -104,13 +97,6 @@ function PureDocumentToolCall({
       type="button"
       className="cursor pointer w-fit border py-2 px-3 rounded-xl flex flex-row items-start justify-between gap-3"
       onClick={(event) => {
-        if (isReadonly) {
-          toast.error(
-            'Viewing files in shared chats is currently not supported.',
-          );
-          return;
-        }
-
         const rect = event.currentTarget.getBoundingClientRect();
 
         const boundingBox = {
@@ -124,6 +110,7 @@ function PureDocumentToolCall({
           ...currentBlock,
           isVisible: true,
           boundingBox,
+          chatId,
         }));
       }}
     >

--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -30,6 +30,7 @@ type EditorProps = {
   isCurrentVersion: boolean;
   currentVersionIndex: number;
   suggestions: Array<Suggestion>;
+  isReadonly?: boolean;
 };
 
 function PureEditor({
@@ -37,6 +38,7 @@ function PureEditor({
   saveContent,
   suggestions,
   status,
+  isReadonly,
 }: EditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorView | null>(null);
@@ -63,6 +65,7 @@ function PureEditor({
 
       editorRef.current = new EditorView(containerRef.current, {
         state,
+        editable: () => !isReadonly,
       });
     }
 
@@ -79,12 +82,13 @@ function PureEditor({
   useEffect(() => {
     if (editorRef.current) {
       editorRef.current.setProps({
+        editable: () => !isReadonly,
         dispatchTransaction: (transaction) => {
           handleTransaction({ transaction, editorRef, saveContent });
         },
       });
     }
-  }, [saveContent]);
+  }, [saveContent, isReadonly]);
 
   useEffect(() => {
     if (editorRef.current && content) {
@@ -153,7 +157,8 @@ function areEqual(prevProps: EditorProps, nextProps: EditorProps) {
     prevProps.isCurrentVersion === nextProps.isCurrentVersion &&
     !(prevProps.status === 'streaming' && nextProps.status === 'streaming') &&
     prevProps.content === nextProps.content &&
-    prevProps.saveContent === nextProps.saveContent
+    prevProps.saveContent === nextProps.saveContent &&
+    prevProps.isReadonly === nextProps.isReadonly
   );
 }
 

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -3,7 +3,7 @@
 import type { ChatRequestOptions, Message } from 'ai';
 import cx from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
-import { memo, useMemo, useState } from 'react';
+import { memo, useState } from 'react';
 
 import type { Vote } from '@/lib/db/schema';
 
@@ -138,20 +138,20 @@ const PurePreviewMessage = ({
                           <Weather weatherAtLocation={result} />
                         ) : toolName === 'createDocument' ? (
                           <DocumentPreview
-                            isReadonly={isReadonly}
+                            chatId={chatId}
                             result={result}
                           />
                         ) : toolName === 'updateDocument' ? (
                           <DocumentToolResult
                             type="update"
                             result={result}
-                            isReadonly={isReadonly}
+                            chatId={chatId}
                           />
                         ) : toolName === 'requestSuggestions' ? (
                           <DocumentToolResult
                             type="request-suggestions"
                             result={result}
-                            isReadonly={isReadonly}
+                            chatId={chatId}
                           />
                         ) : (
                           <pre>{JSON.stringify(result, null, 2)}</pre>
@@ -169,18 +169,18 @@ const PurePreviewMessage = ({
                       {toolName === 'getWeather' ? (
                         <Weather />
                       ) : toolName === 'createDocument' ? (
-                        <DocumentPreview isReadonly={isReadonly} args={args} />
+                        <DocumentPreview chatId={chatId} args={args} />
                       ) : toolName === 'updateDocument' ? (
                         <DocumentToolCall
                           type="update"
                           args={args}
-                          isReadonly={isReadonly}
+                          chatId={chatId}
                         />
                       ) : toolName === 'requestSuggestions' ? (
                         <DocumentToolCall
                           type="request-suggestions"
                           args={args}
-                          isReadonly={isReadonly}
+                          chatId={chatId}
                         />
                       ) : null}
                     </div>

--- a/hooks/use-block.ts
+++ b/hooks/use-block.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { UIBlock } from '@/components/block';
+import type { UIBlock } from '@/components/block';
 import { useCallback, useMemo } from 'react';
 import useSWR from 'swr';
 
@@ -11,6 +11,7 @@ export const initialBlockData: UIBlock = {
   title: '',
   status: 'idle',
   isVisible: false,
+  chatId: 'init',
   boundingBox: {
     top: 0,
     left: 0,

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -16,7 +16,7 @@ import {
   message,
   vote,
 } from './schema';
-import { BlockKind } from '@/components/block';
+import type { BlockKind } from '@/components/block';
 
 // Optionally, if not using email/pass login, you can
 // use the Drizzle adapter for Auth.js / NextAuth
@@ -173,12 +173,14 @@ export async function saveDocument({
   kind,
   content,
   userId,
+  chatId,
 }: {
   id: string;
   title: string;
   kind: BlockKind;
   content: string;
   userId: string;
+  chatId: string;
 }) {
   try {
     return await db.insert(document).values({
@@ -187,6 +189,7 @@ export async function saveDocument({
       kind,
       content,
       userId,
+      chatId,
       createdAt: new Date(),
     });
   } catch (error) {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -78,6 +78,9 @@ export const document = pgTable(
     userId: uuid('userId')
       .notNull()
       .references(() => user.id),
+    chatId: uuid('chatId')
+      .notNull()
+      .references(() => chat.id),
   },
   (table) => {
     return {


### PR DESCRIPTION
Enhance authentication and document handling with chat integration, so documents can inherit chat's visibility.

- Added public route handling in authentication configuration to allow access to specific API endpoints and added '/api/document' to it.
- Updated document handling in chat API to include chatId for better association between documents and chats.
- Refactored document retrieval logic to check for chat visibility and user authorization.
- Enhanced block components to support read-only and editable modes, improving user experience in collaborative environments.
- Introduced chatId in various components and hooks to maintain context across document interactions.

This commit makes documents inside a visible chat visible as well by anyone.