### PR TITLE
feat: clear console outputs when closing block

### DIFF
--- a/components/console.tsx
+++ b/components/console.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { ConsoleOutput } from './block';
 import { cn } from '@/lib/utils';
+import { useBlockSelector } from '@/hooks/use-block';
 
 interface ConsoleProps {
   consoleOutputs: Array<ConsoleOutput>;
@@ -20,6 +21,8 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
   const [height, setHeight] = useState<number>(300);
   const [isResizing, setIsResizing] = useState(false);
   const consoleEndRef = useRef<HTMLDivElement>(null);
+
+  const isBlockVisible = useBlockSelector((state) => state.isVisible);
 
   const minHeight = 100;
   const maxHeight = 800;
@@ -56,6 +59,12 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
   useEffect(() => {
     consoleEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [consoleOutputs]);
+
+  useEffect(() => {
+    if (!isBlockVisible) {
+      setConsoleOutputs([]);
+    }
+  }, [isBlockVisible, setConsoleOutputs]);
 
   return consoleOutputs.length > 0 ? (
     <>


### PR DESCRIPTION
Previously, the console outputs persisted even after the block was closed. This pull request ensures the console is cleared when the block is closed.