### PR TITLE
fix: prevent empty code execution outputs after remount

### DIFF
--- a/components/console.tsx
+++ b/components/console.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { ConsoleOutput } from './block';
 import { cn } from '@/lib/utils';
+import { useBlockSelector } from '@/hooks/use-block';
 
 interface ConsoleProps {
   consoleOutputs: Array<ConsoleOutput>;
@@ -20,6 +21,8 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
   const [height, setHeight] = useState<number>(300);
   const [isResizing, setIsResizing] = useState(false);
   const consoleEndRef = useRef<HTMLDivElement>(null);
+
+  const isBlockVisible = useBlockSelector((state) => state.isVisible);
 
   const minHeight = 100;
   const maxHeight = 800;
@@ -56,6 +59,12 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
   useEffect(() => {
     consoleEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [consoleOutputs]);
+
+  useEffect(() => {
+    if (!isBlockVisible) {
+      setConsoleOutputs([]);
+    }
+  }, [isBlockVisible, setConsoleOutputs]);
 
   return consoleOutputs.length > 0 ? (
     <>
@@ -115,14 +124,16 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
                 consoleOutput.status,
               ) ? (
                 <div className="flex flex-row gap-2">
-                  <div className="animate-spin size-fit self-center">
+                  <div className="animate-spin size-fit self-center mb-auto mt-0.5">
                     <LoaderIcon />
                   </div>
                   <div className="text-muted-foreground">
                     {consoleOutput.status === 'in_progress'
                       ? 'Initializing...'
                       : consoleOutput.status === 'loading_packages'
-                        ? 'Loading Packages...'
+                        ? consoleOutput.contents.map((content) =>
+                            content.type === 'text' ? content.value : null,
+                          )
                         : null}
                   </div>
                 </div>


### PR DESCRIPTION
Previously, the block content would remain empty after closing and reopening – this pull requests fixes this behavior.