### PR TITLE
fix: lock horizontal scroll for console

### DIFF
--- a/components/console.tsx
+++ b/components/console.tsx
@@ -78,7 +78,7 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
 
       <div
         className={cn(
-          'fixed flex flex-col bottom-0 dark:bg-zinc-900 bg-zinc-50 w-full border-t z-40 overflow-y-scroll dark:border-zinc-700 border-zinc-200',
+          'fixed flex flex-col bottom-0 dark:bg-zinc-900 bg-zinc-50 w-full border-t z-40 overflow-y-scroll overflow-x-hidden dark:border-zinc-700 border-zinc-200',
           {
             'select-none': isResizing,
           },
@@ -151,7 +151,7 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
                     ) : (
                       <div
                         key={`${consoleOutput.id}-${index}`}
-                        className="whitespace-pre-line"
+                        className="whitespace-pre-line break-words w-full"
                       >
                         {content.value}
                       </div>

--- a/components/console.tsx
+++ b/components/console.tsx
@@ -138,7 +138,7 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
                   </div>
                 </div>
               ) : (
-                <div className="dark:text-zinc-50 text-zinc-900 w-full flex flex-col gap-2">
+                <div className="dark:text-zinc-50 text-zinc-900 w-full flex flex-col gap-2 overflow-x-scroll">
                   {consoleOutput.contents.map((content, index) =>
                     content.type === 'image' ? (
                       <picture key={`${consoleOutput.id}-${index}`}>


### PR DESCRIPTION
Previously, long outputs would overflow the console window out of bounds – this pull requests prevents that from happening and ensures the contents remain inside the console.