### PR TITLE
fix: preserve cursor position on code editor saves

### DIFF
--- a/components/block.tsx
+++ b/components/block.tsx
@@ -428,9 +428,7 @@ function PureBlock({
                 <BlockCloseButton />
 
                 <div className="flex flex-col">
-                  <div className="font-medium">
-                    {document?.title ?? block.title}
-                  </div>
+                  <div className="font-medium">{block.title}</div>
 
                   {isContentDirty ? (
                     <div className="text-sm text-muted-foreground">

--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -75,10 +75,7 @@ function PureCodeEditor({ content, saveContent, status }: EditorProps) {
     if (editorRef.current && content) {
       const currentContent = editorRef.current.state.doc.toString();
 
-      if (
-        status === 'streaming' ||
-        (currentContent.length == 0 && content.length > 0)
-      ) {
+      if (status === 'streaming' || currentContent !== content) {
         const transaction = editorRef.current.state.update({
           changes: {
             from: 0,

--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -59,9 +59,12 @@ function PureCodeEditor({ content, saveContent, status }: EditorProps) {
         }
       });
 
+      const currentSelection = editorRef.current.state.selection;
+
       const newState = EditorState.create({
         doc: editorRef.current.state.doc,
         extensions: [basicSetup, python(), oneDark, updateListener],
+        selection: currentSelection,
       });
 
       editorRef.current.setState(newState);
@@ -72,7 +75,10 @@ function PureCodeEditor({ content, saveContent, status }: EditorProps) {
     if (editorRef.current && content) {
       const currentContent = editorRef.current.state.doc.toString();
 
-      if (status === 'streaming' || currentContent !== content) {
+      if (
+        status === 'streaming' ||
+        (currentContent.length == 0 && content.length > 0)
+      ) {
         const transaction = editorRef.current.state.update({
           changes: {
             from: 0,

--- a/components/document-preview.tsx
+++ b/components/document-preview.tsx
@@ -145,6 +145,7 @@ const PureHitboxLayer = ({
           ? { ...block, isVisible: true }
           : {
               ...block,
+              title: result.title,
               documentId: result.id,
               kind: result.kind,
               isVisible: true,


### PR DESCRIPTION
Previously when using the code editor, updates and saves would reset the cursor position – this pull requests fixes this behavior and persists the current cursor position.