### PR TITLE
fix: correct messages comparison in Block memo function

### DIFF
--- a/components/block.tsx
+++ b/components/block.tsx
@@ -561,7 +561,7 @@ export const Block = memo(PureBlock, (prevProps, nextProps) => {
   if (prevProps.isLoading !== nextProps.isLoading) return false;
   if (!equal(prevProps.votes, nextProps.votes)) return false;
   if (prevProps.input !== nextProps.input) return false;
-  if (!equal(prevProps.messages, nextProps.messages.length)) return false;
+  if (!equal(prevProps.messages, nextProps.messages)) return false;
 
   return true;
 });


### PR DESCRIPTION
## Description
Fixes a suspected bug in the Block component's memo comparison function where messages were being incorrectly compared against messages.length. This could cause unnecessary re-renders in the chat interface.

## Before
`if (!equal(prevProps.messages, nextProps.messages.length))`

## After
`if (!equal(prevProps.messages, nextProps.messages))`