### PR TITLE
(feat/canvas): Add Spreadsheet Support (wip)

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -212,7 +212,10 @@ export async function POST(request: Request) {
                     - Create meaningful column headers based on the context and chat history
                     - Keep data types consistent within columns
                     - If the title doesn't suggest specific columns, create a general-purpose structure`,
-                  prompt: title,
+                  prompt:
+                    title +
+                    '\n\nChat History:\n' +
+                    coreMessages.map((msg) => msg.content).join('\n'),
                   schema: z.object({
                     headers: z
                       .array(z.string())

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -214,18 +214,16 @@ export async function POST(request: Request) {
                     - If the title doesn't suggest specific columns, create a general-purpose structure`,
                   prompt: title,
                   schema: z.object({
-                    headers: z.array(z.string()).describe('Column headers for the spreadsheet'),
+                    headers: z
+                      .array(z.string())
+                      .describe('Column headers for the spreadsheet'),
                     rows: z.array(z.array(z.string())).describe('Data rows'),
                   }),
                 });
 
-
                 let spreadsheetData: { headers: string[]; rows: string[][] } = {
                   headers: [],
-                  rows: [
-                    [],
-                    [],
-                  ],
+                  rows: [[], []],
                 };
 
                 for await (const delta of fullStream) {
@@ -233,14 +231,23 @@ export async function POST(request: Request) {
 
                   if (type === 'object') {
                     const { object } = delta;
-                    if (object && Array.isArray(object.headers) && Array.isArray(object.rows)) {
+                    if (
+                      object &&
+                      Array.isArray(object.headers) &&
+                      Array.isArray(object.rows)
+                    ) {
                       // Validate and normalize the data
-                      const headers = object.headers.map(h => String(h || ''));
+                      const headers = object.headers.map((h) =>
+                        String(h || ''),
+                      );
                       const rows = object.rows.map((row) => {
                         // Handle undefined row by creating empty array
-                        const safeRow = (row || []).map(cell => String(cell || ''));
+                        const safeRow = (row || []).map((cell) =>
+                          String(cell || ''),
+                        );
                         // Ensure row length matches headers
-                        while (safeRow.length < headers.length) safeRow.push('');
+                        while (safeRow.length < headers.length)
+                          safeRow.push('');
                         return safeRow.slice(0, headers.length);
                       });
 
@@ -248,7 +255,7 @@ export async function POST(request: Request) {
                     }
                   }
                 }
-                
+
                 draftText = JSON.stringify(spreadsheetData);
                 dataStream.writeData({
                   type: 'spreadsheet-delta',
@@ -387,10 +394,14 @@ export async function POST(request: Request) {
                     
                     Example response format:
                     {"headers":["Name","Email","Phone"],"rows":[["John","john@example.com","123-456-7890"],["Jane","jane@example.com","098-765-4321"]]}`,
-                  prompt: `${description}\n\nChat History:\n${coreMessages.map(msg => msg.content).join('\n')}`,
+                  prompt: `${description}\n\nChat History:\n${coreMessages.map((msg) => msg.content).join('\n')}`,
                   schema: z.object({
-                    headers: z.array(z.string()).describe('Column headers for the spreadsheet'),
-                    rows: z.array(z.array(z.string())).describe('Sample data rows'),
+                    headers: z
+                      .array(z.string())
+                      .describe('Column headers for the spreadsheet'),
+                    rows: z
+                      .array(z.array(z.string()))
+                      .describe('Sample data rows'),
                   }),
                 });
 
@@ -402,18 +413,28 @@ export async function POST(request: Request) {
 
                   if (type === 'object') {
                     const { object } = delta;
-                    if (object && Array.isArray(object.headers) && Array.isArray(object.rows)) {
+                    if (
+                      object &&
+                      Array.isArray(object.headers) &&
+                      Array.isArray(object.rows)
+                    ) {
                       // Validate and normalize the data
-                      const headers = object.headers.map((h: any) => String(h || ''));
-                      const rows = object.rows.map((row: (string | undefined)[] | undefined) => {
-                        const normalizedRow = (row || []).map((cell: any) => String(cell || ''));
-                        // Ensure row length matches new headers length
-                        while (normalizedRow.length < headers.length) {
-                          normalizedRow.push('');
-                        }
-                        return normalizedRow.slice(0, headers.length);
-                      });
-                      
+                      const headers = object.headers.map((h: any) =>
+                        String(h || ''),
+                      );
+                      const rows = object.rows.map(
+                        (row: (string | undefined)[] | undefined) => {
+                          const normalizedRow = (row || []).map((cell: any) =>
+                            String(cell || ''),
+                          );
+                          // Ensure row length matches new headers length
+                          while (normalizedRow.length < headers.length) {
+                            normalizedRow.push('');
+                          }
+                          return normalizedRow.slice(0, headers.length);
+                        },
+                      );
+
                       const newData = { headers, rows };
                       draftText = JSON.stringify(newData);
                       dataStream.writeData({

--- a/components/block-actions.tsx
+++ b/components/block-actions.tsx
@@ -1,5 +1,12 @@
 import { cn } from '@/lib/utils';
-import { ClockRewind, CopyIcon, RedoIcon, UndoIcon } from './icons';
+import {
+  ClockRewind,
+  CopyIcon,
+  RedoIcon,
+  UndoIcon,
+  ArrowUpIcon,
+  DownloadIcon,
+} from './icons';
 import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { useCopyToClipboard } from 'usehooks-ts';
@@ -7,6 +14,7 @@ import { toast } from 'sonner';
 import { ConsoleOutput, UIBlock } from './block';
 import { Dispatch, memo, SetStateAction } from 'react';
 import { RunCodeButton } from './run-code-button';
+import { exportToCSV } from '@/lib/spreadsheet';
 
 interface BlockActionsProps {
   block: UIBlock;
@@ -27,10 +35,36 @@ function PureBlockActions({
 }: BlockActionsProps) {
   const [_, copyToClipboard] = useCopyToClipboard();
 
+  const handleExportCSV = () => {
+    try {
+      exportToCSV(block.content);
+      toast.success('CSV file downloaded!');
+    } catch (error) {
+      console.error(error);
+      toast.error('Failed to export CSV');
+    }
+  };
+
   return (
     <div className="flex flex-row gap-1">
       {block.kind === 'code' && (
         <RunCodeButton block={block} setConsoleOutputs={setConsoleOutputs} />
+      )}
+
+      {block.kind === 'spreadsheet' && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              className="p-2 h-fit dark:hover:bg-zinc-700 !pointer-events-auto"
+              onClick={handleExportCSV}
+              disabled={block.status === 'streaming'}
+            >
+              <DownloadIcon size={18} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Download as CSV</TooltipContent>
+        </Tooltip>
       )}
 
       {block.kind === 'text' && (

--- a/components/block.tsx
+++ b/components/block.tsx
@@ -34,8 +34,12 @@ import { Console } from './console';
 import { useSidebar } from './ui/sidebar';
 import { useBlock } from '@/hooks/use-block';
 import equal from 'fast-deep-equal';
+import { SpreadsheetEditor } from './spreadsheet-editor';
 
-export type BlockKind = 'text' | 'code';
+/** Type representing the possible block kinds: 'text' | 'code' | 'spreadsheet' */
+export type BlockKind = 'text' | 'code' | 'spreadsheet';
+
+export const BLOCK_KINDS: BlockKind[] = ['text', 'code', 'spreadsheet'];
 
 export interface UIBlock {
   title: string;
@@ -466,6 +470,7 @@ function PureBlock({
                 {
                   'py-2 px-2': block.kind === 'code',
                   'py-8 md:p-20 px-4': block.kind === 'text',
+                  'w-full': block.kind === 'spreadsheet',
                 },
               )}
             >
@@ -512,8 +517,19 @@ function PureBlock({
                       newContent={getDocumentContentById(currentVersionIndex)}
                     />
                   )
+                ) : block.kind === 'spreadsheet' ? (
+                  <SpreadsheetEditor
+                    content={
+                      isCurrentVersion
+                        ? block.content
+                        : getDocumentContentById(currentVersionIndex)
+                    }
+                    isCurrentVersion={isCurrentVersion}
+                    currentVersionIndex={currentVersionIndex}
+                    status={block.status}
+                    saveContent={saveContent}
+                  />
                 ) : null}
-
                 {suggestions ? (
                   <div className="md:hidden h-dvh w-12 shrink-0" />
                 ) : null}

--- a/components/data-stream-handler.tsx
+++ b/components/data-stream-handler.tsx
@@ -1,25 +1,25 @@
-"use client";
+'use client';
 
-import { useChat } from "ai/react";
-import { useEffect, useRef } from "react";
-import { BlockKind } from "./block";
-import { Suggestion } from "@/lib/db/schema";
-import { initialBlockData, useBlock } from "@/hooks/use-block";
-import { useUserMessageId } from "@/hooks/use-user-message-id";
-import { cx } from "class-variance-authority";
+import { useChat } from 'ai/react';
+import { useEffect, useRef } from 'react';
+import { BlockKind } from './block';
+import { Suggestion } from '@/lib/db/schema';
+import { initialBlockData, useBlock } from '@/hooks/use-block';
+import { useUserMessageId } from '@/hooks/use-user-message-id';
+import { cx } from 'class-variance-authority';
 
 type DataStreamDelta = {
   type:
-    | "text-delta"
-    | "code-delta"
-    | "spreadsheet-delta"
-    | "title"
-    | "id"
-    | "suggestion"
-    | "clear"
-    | "finish"
-    | "user-message-id"
-    | "kind";
+    | 'text-delta'
+    | 'code-delta'
+    | 'spreadsheet-delta'
+    | 'title'
+    | 'id'
+    | 'suggestion'
+    | 'clear'
+    | 'finish'
+    | 'user-message-id'
+    | 'kind';
   content: string | Suggestion;
 };
 
@@ -36,82 +36,82 @@ export function DataStreamHandler({ id }: { id: string }) {
     lastProcessedIndex.current = dataStream.length - 1;
 
     (newDeltas as DataStreamDelta[]).forEach((delta: DataStreamDelta) => {
-      if (delta.type === "user-message-id") {
+      if (delta.type === 'user-message-id') {
         setUserMessageIdFromServer(delta.content as string);
         return;
       }
 
       setBlock((draftBlock) => {
         if (!draftBlock) {
-          return { ...initialBlockData, status: "streaming" };
+          return { ...initialBlockData, status: 'streaming' };
         }
 
         switch (delta.type) {
-          case "id":
+          case 'id':
             return {
               ...draftBlock,
               documentId: delta.content as string,
-              status: "streaming",
+              status: 'streaming',
             };
 
-          case "title":
+          case 'title':
             return {
               ...draftBlock,
               title: delta.content as string,
-              status: "streaming",
+              status: 'streaming',
             };
 
-          case "kind":
+          case 'kind':
             return {
               ...draftBlock,
               kind: delta.content as BlockKind,
-              status: "streaming",
+              status: 'streaming',
             };
 
-          case "text-delta":
+          case 'text-delta':
             return {
               ...draftBlock,
               content: draftBlock.content + (delta.content as string),
               isVisible:
-                draftBlock.status === "streaming" &&
+                draftBlock.status === 'streaming' &&
                 draftBlock.content.length > 400 &&
                 draftBlock.content.length < 450
                   ? true
                   : draftBlock.isVisible,
-              status: "streaming",
+              status: 'streaming',
             };
 
-          case "code-delta":
+          case 'code-delta':
             return {
               ...draftBlock,
               content: delta.content as string,
               isVisible:
-                draftBlock.status === "streaming" &&
+                draftBlock.status === 'streaming' &&
                 draftBlock.content.length > 300 &&
                 draftBlock.content.length < 310
                   ? true
                   : draftBlock.isVisible,
-              status: "streaming",
+              status: 'streaming',
             };
-          case "spreadsheet-delta":
+          case 'spreadsheet-delta':
             return {
               ...draftBlock,
               content: delta.content as string,
               isVisible: true,
-              status: "streaming",
+              status: 'streaming',
             };
 
-          case "clear":
+          case 'clear':
             return {
               ...draftBlock,
-              content: "",
-              status: "streaming",
+              content: '',
+              status: 'streaming',
             };
 
-          case "finish":
+          case 'finish':
             return {
               ...draftBlock,
-              status: "idle",
+              status: 'idle',
             };
 
           default:

--- a/components/data-stream-handler.tsx
+++ b/components/data-stream-handler.tsx
@@ -1,24 +1,25 @@
-'use client';
+"use client";
 
-import { useChat } from 'ai/react';
-import { useEffect, useRef } from 'react';
-import { BlockKind } from './block';
-import { Suggestion } from '@/lib/db/schema';
-import { initialBlockData, useBlock } from '@/hooks/use-block';
-import { useUserMessageId } from '@/hooks/use-user-message-id';
-import { cx } from 'class-variance-authority';
+import { useChat } from "ai/react";
+import { useEffect, useRef } from "react";
+import { BlockKind } from "./block";
+import { Suggestion } from "@/lib/db/schema";
+import { initialBlockData, useBlock } from "@/hooks/use-block";
+import { useUserMessageId } from "@/hooks/use-user-message-id";
+import { cx } from "class-variance-authority";
 
 type DataStreamDelta = {
   type:
-    | 'text-delta'
-    | 'code-delta'
-    | 'title'
-    | 'id'
-    | 'suggestion'
-    | 'clear'
-    | 'finish'
-    | 'user-message-id'
-    | 'kind';
+    | "text-delta"
+    | "code-delta"
+    | "spreadsheet-delta"
+    | "title"
+    | "id"
+    | "suggestion"
+    | "clear"
+    | "finish"
+    | "user-message-id"
+    | "kind";
   content: string | Suggestion;
 };
 
@@ -35,75 +36,82 @@ export function DataStreamHandler({ id }: { id: string }) {
     lastProcessedIndex.current = dataStream.length - 1;
 
     (newDeltas as DataStreamDelta[]).forEach((delta: DataStreamDelta) => {
-      if (delta.type === 'user-message-id') {
+      if (delta.type === "user-message-id") {
         setUserMessageIdFromServer(delta.content as string);
         return;
       }
 
       setBlock((draftBlock) => {
         if (!draftBlock) {
-          return { ...initialBlockData, status: 'streaming' };
+          return { ...initialBlockData, status: "streaming" };
         }
 
         switch (delta.type) {
-          case 'id':
+          case "id":
             return {
               ...draftBlock,
               documentId: delta.content as string,
-              status: 'streaming',
+              status: "streaming",
             };
 
-          case 'title':
+          case "title":
             return {
               ...draftBlock,
               title: delta.content as string,
-              status: 'streaming',
+              status: "streaming",
             };
 
-          case 'kind':
+          case "kind":
             return {
               ...draftBlock,
               kind: delta.content as BlockKind,
-              status: 'streaming',
+              status: "streaming",
             };
 
-          case 'text-delta':
+          case "text-delta":
             return {
               ...draftBlock,
               content: draftBlock.content + (delta.content as string),
               isVisible:
-                draftBlock.status === 'streaming' &&
+                draftBlock.status === "streaming" &&
                 draftBlock.content.length > 400 &&
                 draftBlock.content.length < 450
                   ? true
                   : draftBlock.isVisible,
-              status: 'streaming',
+              status: "streaming",
             };
 
-          case 'code-delta':
+          case "code-delta":
             return {
               ...draftBlock,
               content: delta.content as string,
               isVisible:
-                draftBlock.status === 'streaming' &&
+                draftBlock.status === "streaming" &&
                 draftBlock.content.length > 300 &&
                 draftBlock.content.length < 310
                   ? true
                   : draftBlock.isVisible,
-              status: 'streaming',
+              status: "streaming",
             };
-
-          case 'clear':
+          case "spreadsheet-delta":
             return {
               ...draftBlock,
-              content: '',
-              status: 'streaming',
+              content: delta.content as string,
+              isVisible: true,
+              status: "streaming",
             };
 
-          case 'finish':
+          case "clear":
             return {
               ...draftBlock,
-              status: 'idle',
+              content: "",
+              status: "streaming",
+            };
+
+          case "finish":
+            return {
+              ...draftBlock,
+              status: "idle",
             };
 
           default:

--- a/components/document-preview.tsx
+++ b/components/document-preview.tsx
@@ -8,7 +8,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
-import { UIBlock } from './block';
+import { BlockKind, UIBlock } from './block';
 import { FileIcon, FullscreenIcon, LoaderIcon } from './icons';
 import { cn, fetcher } from '@/lib/utils';
 import { Document } from '@/lib/db/schema';
@@ -19,6 +19,7 @@ import { DocumentToolCall, DocumentToolResult } from './document';
 import { CodeEditor } from './code-editor';
 import { useBlock } from '@/hooks/use-block';
 import equal from 'fast-deep-equal';
+import { SpreadsheetEditor } from './spreadsheet-editor';
 
 interface DocumentPreviewProps {
   isReadonly: boolean;
@@ -145,7 +146,6 @@ const PureHitboxLayer = ({
           ? { ...block, isVisible: true }
           : {
               ...block,
-              title: result.title,
               documentId: result.id,
               kind: result.kind,
               isVisible: true,
@@ -168,13 +168,7 @@ const PureHitboxLayer = ({
       onClick={handleClick}
       role="presentation"
       aria-hidden="true"
-    >
-      <div className="w-full p-4 flex justify-end items-center">
-        <div className="absolute right-[9px] top-[13px] p-2 hover:dark:bg-zinc-700 rounded-md hover:bg-zinc-100">
-          <FullscreenIcon />
-        </div>
-      </div>
-    </div>
+    />
   );
 };
 
@@ -203,7 +197,9 @@ const PureDocumentHeader = ({
       </div>
       <div className="-translate-y-1 sm:translate-y-0 font-medium">{title}</div>
     </div>
-    <div className="w-8" />
+    <div>
+      <FullscreenIcon />
+    </div>
   </div>
 );
 
@@ -242,6 +238,12 @@ const DocumentContent = ({ document }: { document: Document }) => {
         <div className="flex flex-1 relative w-full">
           <div className="absolute inset-0">
             <CodeEditor {...commonProps} />
+          </div>
+        </div>
+      ) : document.kind === 'spreadsheet' ? (
+        <div className="flex flex-1 relative w-full p-4">
+          <div className="absolute inset-0">
+            <SpreadsheetEditor {...commonProps} />
           </div>
         </div>
       ) : null}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -1127,9 +1127,9 @@ export const DownloadIcon = ({ size = 16 }: { size?: number }) => (
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
   >
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
     <polyline points="7 10 12 15 17 10" />

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -1119,3 +1119,20 @@ export const FullscreenIcon = ({ size = 16 }: { size?: number }) => (
     ></path>
   </svg>
 );
+export const DownloadIcon = ({ size = 16 }: { size?: number }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" x2="12" y1="15" y2="3" />
+  </svg>
+);

--- a/components/spreadsheet-editor.tsx
+++ b/components/spreadsheet-editor.tsx
@@ -1,0 +1,508 @@
+'use client';
+
+import React, { useEffect, useState, useRef, KeyboardEvent, useCallback, memo } from 'react';
+import { cn } from '@/lib/utils';
+import { ChevronDownIcon, PlusIcon, UploadIcon } from './icons';
+
+interface SpreadsheetData {
+  headers: string[];
+  rows: string[][];
+}
+
+interface SpreadsheetEditorProps {
+  content: string;
+  saveContent: (updatedContent: string, debounce: boolean) => void;
+  status: 'streaming' | 'idle';
+  isCurrentVersion: boolean;
+  currentVersionIndex: number;
+}
+
+const PureSpreadsheetEditor = ({
+  content,
+  saveContent,
+  status,
+  isCurrentVersion,
+}: SpreadsheetEditorProps) => {
+  const [data, setData] = useState<SpreadsheetData>(() => {
+    try {
+      const parsed = JSON.parse(content);
+      return {
+        headers: Array.isArray(parsed.headers) ? parsed.headers : ['A', 'B', 'C'],
+        rows: Array.isArray(parsed.rows) ? parsed.rows.map((row: unknown) => 
+          Array.isArray(row) ? row.map(cell => String(cell || '')) : new Array(parsed.headers?.length || 3).fill('')
+        ) : [new Array(3).fill(''), new Array(3).fill('')]
+      };
+    } catch {
+      return { headers: ['A', 'B', 'C'], rows: [['', '', ''], ['', '', '']] };
+    }
+  });
+
+  // Memoize content update handler
+  const handleContentUpdate = useCallback((newContent: string) => {
+    try {
+      const parsed = JSON.parse(newContent);
+      if (parsed && typeof parsed === 'object') {
+        setData(prevData => {
+          const newData = {
+            headers: Array.isArray(parsed.headers) ? parsed.headers.map((h: unknown) => String(h || '')) : prevData.headers,
+            rows: Array.isArray(parsed.rows) ? parsed.rows.map((row: unknown) => 
+              Array.isArray(row) ? row.map(cell => String(cell || '')) : new Array(parsed.headers?.length || prevData.headers.length).fill('')
+            ) : prevData.rows
+          };
+          // Normalize rows
+          newData.rows = newData.rows.map((row: string[]) => {
+            const normalizedRow = [...row];
+            while (normalizedRow.length < newData.headers.length) {
+              normalizedRow.push('');
+            }
+            return normalizedRow.slice(0, newData.headers.length);
+          });
+          return newData;
+        });
+      }
+    } catch (error) {
+      console.error('Failed to parse updated content:', error);
+    }
+  }, []); // No dependencies needed as we use functional updates
+
+  useEffect(() => {
+    const currentContent = JSON.stringify({
+      headers: data.headers,
+      rows: data.rows
+    });
+    
+    if (content && content !== currentContent) {
+      handleContentUpdate(content);
+    }
+  }, [content, handleContentUpdate]);
+
+  const [editingCell, setEditingCell] = useState<{
+    row: number;
+    col: number;
+    value: string;
+  } | null>(null);
+
+  const [selectedCell, setSelectedCell] = useState<{
+    row: number;
+    col: number;
+  } | null>(null);
+
+  const [hoveredColumn, setHoveredColumn] = useState<number | null>(null);
+  const [hoveredRow, setHoveredRow] = useState<number | null>(null);
+  const [showColumnMenu, setShowColumnMenu] = useState<number | null>(null);
+  const [showRowMenu, setShowRowMenu] = useState<number | null>(null);
+
+  const editorRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Memoize cell and header change handlers
+  const handleHeaderChange = useCallback((index: number, value: string) => {
+    setData(prevData => {
+      const newData = {
+        headers: [...prevData.headers],
+        rows: [...prevData.rows]
+      };
+      newData.headers[index] = value;
+      saveContent(JSON.stringify(newData), true);
+      return newData;
+    });
+  }, [saveContent]);
+
+  const handleCellChange = useCallback((rowIndex: number, colIndex: number, value: string) => {
+    setData(prevData => {
+      const newData = {
+        headers: [...prevData.headers],
+        rows: prevData.rows.map(row => [...row])
+      };
+      if (!newData.rows[rowIndex]) {
+        newData.rows[rowIndex] = [];
+      }
+      newData.rows[rowIndex][colIndex] = value;
+      saveContent(JSON.stringify(newData), true);
+      return newData;
+    });
+  }, [saveContent]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    if (!selectedCell) return;
+
+    const { row, col } = selectedCell;
+    let newRow = row;
+    let newCol = col;
+
+    switch (e.key) {
+      case 'ArrowUp':
+        newRow = Math.max(0, row - 1);
+        break;
+      case 'ArrowDown':
+        newRow = Math.min(data.rows.length - 1, row + 1);
+        break;
+      case 'ArrowLeft':
+        newCol = Math.max(0, col - 1);
+        break;
+      case 'ArrowRight':
+        newCol = Math.min(data.headers.length - 1, col + 1);
+        break;
+      case 'Enter':
+        if (!editingCell) {
+          setEditingCell({ row, col, value: data.rows[row][col] });
+        }
+        break;
+      case 'Escape':
+        setEditingCell(null);
+        break;
+      default:
+        return;
+    }
+
+    if (newRow !== row || newCol !== col) {
+      e.preventDefault();
+      setSelectedCell({ row: newRow, col: newCol });
+      setEditingCell(null);
+    }
+  }, [selectedCell, data.rows.length, data.headers.length, editingCell]);
+
+  const addColumn = useCallback((index?: number) => {
+    setData(prevData => {
+      const insertAt = typeof index === 'number' ? index : prevData.headers.length;
+      const newData = {
+        headers: [...prevData.headers],
+        rows: prevData.rows.map(row => [...row])
+      };
+      
+      // Generate next column name (A, B, C, ..., Z, AA, AB, ...)
+      const getNextColumnName = (n: number) => {
+        let name = '';
+        while (n >= 0) {
+          name = String.fromCharCode(65 + (n % 26)) + name;
+          n = Math.floor(n / 26) - 1;
+        }
+        return name;
+      };
+
+      newData.headers.splice(insertAt, 0, getNextColumnName(prevData.headers.length));
+      newData.rows.forEach(row => row.splice(insertAt, 0, ''));
+      
+      saveContent(JSON.stringify(newData), true);
+      return newData;
+    });
+  }, [saveContent]);
+
+  const deleteColumn = useCallback((index: number) => {
+    setData(prevData => {
+      if (prevData.headers.length <= 1) return prevData;
+
+      const newData = {
+        headers: [...prevData.headers],
+        rows: prevData.rows.map(row => [...row])
+      };
+
+      newData.headers.splice(index, 1);
+      newData.rows.forEach(row => row.splice(index, 1));
+      
+      saveContent(JSON.stringify(newData), true);
+      return newData;
+    });
+  }, [saveContent]);
+
+  const addRow = useCallback((index?: number) => {
+    setData(prevData => {
+      const newData = {
+        headers: [...prevData.headers],
+        rows: [...prevData.rows]
+      };
+      const newRow = new Array(prevData.headers.length).fill('');
+      
+      if (typeof index === 'number') {
+        newData.rows.splice(index, 0, newRow);
+      } else {
+        newData.rows.push(newRow);
+      }
+      
+      saveContent(JSON.stringify(newData), true);
+      return newData;
+    });
+  }, [saveContent]);
+
+  const deleteRow = useCallback((index: number) => {
+    setData(prevData => {
+      if (prevData.rows.length <= 1) return prevData;
+
+      const newData = {
+        headers: [...prevData.headers],
+        rows: [...prevData.rows]
+      };
+      newData.rows.splice(index, 1);
+      
+      saveContent(JSON.stringify(newData), true);
+      return newData;
+    });
+  }, [saveContent]);
+
+  if (!isCurrentVersion || status === 'streaming') {
+    return (
+      <div className="w-full overflow-x-auto">
+        <table className="min-w-full border-collapse">
+          <thead>
+            <tr>
+              <th className="w-10 bg-muted border p-2"></th>
+              {data.headers.map((header, i) => (
+                <th key={i} className="border p-2 bg-muted min-w-[100px]">
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                <td className="border p-2 bg-muted text-center text-sm text-muted-foreground">
+                  {rowIndex + 1}
+                </td>
+                {row.map((cell, colIndex) => (
+                  <td key={colIndex} className="border p-2 min-w-[100px]">
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  return (
+    <div 
+      className="w-full overflow-x-auto"
+      ref={editorRef}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
+      <table className="min-w-full border-collapse relative">
+        <thead>
+          <tr>
+            <th className="w-10 bg-muted border p-2"></th>
+            {data.headers.map((header, i) => (
+              <th 
+                key={i} 
+                className={cn(
+                  "border p-2 bg-muted min-w-[100px] relative group",
+                  hoveredColumn === i && "bg-muted/80",
+                  "hover:cursor-pointer"
+                )}
+                onMouseEnter={() => setHoveredColumn(i)}
+                onMouseLeave={() => setHoveredColumn(null)}
+              >
+                <div className="flex items-center justify-between">
+                  <input
+                    type="text"
+                    value={header}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      handleHeaderChange(i, e.target.value);
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                    onFocus={(e) => {
+                      e.stopPropagation();
+                      e.target.select();
+                    }}
+                    className="w-full bg-transparent focus:outline-none text-center"
+                  />
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowColumnMenu(showColumnMenu === i ? null : i);
+                    }}
+                    className="opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    <ChevronDownIcon size={16} />
+                  </button>
+                </div>
+                {showColumnMenu === i && (
+                  <div className="absolute top-full left-0 mt-1 w-40 bg-popover border rounded-md shadow-md z-10">
+                    <button
+                      onClick={() => { addColumn(i); setShowColumnMenu(null); }}
+                      className="w-full px-3 py-2 text-left hover:bg-muted"
+                    >
+                      Insert column left
+                    </button>
+                    <button
+                      onClick={() => { addColumn(i + 1); setShowColumnMenu(null); }}
+                      className="w-full px-3 py-2 text-left hover:bg-muted"
+                    >
+                      Insert column right
+                    </button>
+                    <button
+                      onClick={() => { deleteColumn(i); setShowColumnMenu(null); }}
+                      className="w-full px-3 py-2 text-left hover:bg-muted text-destructive"
+                    >
+                      Delete column
+                    </button>
+                  </div>
+                )}
+              </th>
+            ))}
+            <th className="w-10 bg-muted border p-2">
+              <button
+                onClick={() => addColumn()}
+                className="w-6 h-6 flex items-center justify-center hover:bg-primary/10 rounded transition-colors"
+                title="Add column"
+              >
+                <PlusIcon size={16} />
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.rows.map((row, rowIndex) => (
+            <tr 
+              key={rowIndex}
+              className={cn(hoveredRow === rowIndex && "bg-muted/5")}
+              onMouseEnter={() => setHoveredRow(rowIndex)}
+              onMouseLeave={() => setHoveredRow(null)}
+            >
+              <td className="border p-2 bg-muted text-center text-sm text-muted-foreground relative group">
+                <div className="flex items-center justify-between">
+                  <span>{rowIndex + 1}</span>
+                  <button
+                    onClick={() => setShowRowMenu(showRowMenu === rowIndex ? null : rowIndex)}
+                    className="opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    <ChevronDownIcon size={16} />
+                  </button>
+                </div>
+                {showRowMenu === rowIndex && (
+                  <div className="absolute top-0 left-full ml-1 w-40 bg-popover border rounded-md shadow-md z-10">
+                    <button
+                      onClick={() => { addRow(rowIndex); setShowRowMenu(null); }}
+                      className="w-full px-3 py-2 text-left hover:bg-muted"
+                    >
+                      Insert row above
+                    </button>
+                    <button
+                      onClick={() => { addRow(rowIndex + 1); setShowRowMenu(null); }}
+                      className="w-full px-3 py-2 text-left hover:bg-muted"
+                    >
+                      Insert row below
+                    </button>
+                    <button
+                      onClick={() => { deleteRow(rowIndex); setShowRowMenu(null); }}
+                      className="w-full px-3 py-2 text-left hover:bg-muted text-destructive"
+                    >
+                      Delete row
+                    </button>
+                  </div>
+                )}
+              </td>
+              {row.map((cell, colIndex) => (
+                <td 
+                  key={colIndex} 
+                  className={cn(
+                    "border p-2 min-w-[100px] relative select-none",
+                    hoveredColumn === colIndex && "bg-muted/5",
+                    selectedCell?.row === rowIndex && selectedCell?.col === colIndex && [
+                      "before:absolute before:inset-[-1px] before:pointer-events-none", 
+                      "before:border-2 before:border-primary before:rounded-sm",
+                      "before:origin-center before:transition-all before:duration-200",
+                      "before:animate-in before:fade-in-0 before:zoom-in-[0.98]",
+                      "after:absolute after:inset-[-1px] after:pointer-events-none",
+                      "after:border-2 after:border-primary/20 after:rounded-sm", 
+                      "after:origin-center after:transition-all after:duration-300",
+                      "after:animate-in after:fade-in-0 after:zoom-in-[1] after:delay-75",
+                      "after:scale-[1.005]"
+                    ]
+                  )}
+                  onClick={() => {
+                    setSelectedCell({ row: rowIndex, col: colIndex });
+                    setEditingCell({ row: rowIndex, col: colIndex, value: cell });
+                  }}
+                >
+                  {editingCell?.row === rowIndex && editingCell?.col === colIndex ? (
+                    <input
+                      ref={inputRef}
+                      type="text"
+                      value={editingCell.value}
+                      onChange={(e) =>
+                        setEditingCell({
+                          ...editingCell,
+                          value: e.target.value,
+                        })
+                      }
+                      onBlur={() => {
+                        handleCellChange(rowIndex, colIndex, editingCell.value);
+                        setEditingCell(null);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          handleCellChange(rowIndex, colIndex, editingCell.value);
+                          setEditingCell(null);
+                          setSelectedCell({ row: rowIndex + 1, col: colIndex });
+                        } else if (e.key === 'Escape') {
+                          setEditingCell(null);
+                        } else if (e.key === 'Tab') {
+                          e.preventDefault();
+                          handleCellChange(rowIndex, colIndex, editingCell.value);
+                          setEditingCell(null);
+                          setSelectedCell({ 
+                            row: rowIndex, 
+                            col: e.shiftKey ? Math.max(0, colIndex - 1) : Math.min(data.headers.length - 1, colIndex + 1) 
+                          });
+                        }
+                      }}
+                      className="w-full bg-transparent focus:outline-none"
+                      autoFocus
+                    />
+                  ) : (
+                    <div className="min-h-[1.5rem]">
+                      {cell}
+                    </div>
+                  )}
+                </td>
+              ))}
+              <td className="w-10 border p-2 bg-muted">
+                <button
+                  onClick={() => addRow(rowIndex + 1)}
+                  className="opacity-0 group-hover:opacity-100 w-6 h-6 flex items-center justify-center hover:bg-primary/10 rounded transition-colors"
+                  title="Add row below"
+                >
+                  <PlusIcon size={16} />
+                </button>
+              </td>
+            </tr>
+          ))}
+          <tr>
+            <td className="w-10 border p-2 bg-muted">
+              <button
+                onClick={() => addRow()}
+                className="w-6 h-6 flex items-center justify-center hover:bg-primary/10 rounded transition-colors"
+                title="Add row"
+              >
+                <PlusIcon size={16} />
+              </button>
+            </td>
+            {data.headers.map((_, i) => (
+              <td key={i} className="border p-2 bg-muted"></td>
+            ))}
+            <td className="w-10 border p-2 bg-muted"></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function areEqual(prevProps: SpreadsheetEditorProps, nextProps: SpreadsheetEditorProps) {
+  return (
+    prevProps.currentVersionIndex === nextProps.currentVersionIndex &&
+    prevProps.isCurrentVersion === nextProps.isCurrentVersion &&
+    !(prevProps.status === 'streaming' && nextProps.status === 'streaming') &&
+    prevProps.content === nextProps.content &&
+    prevProps.saveContent === nextProps.saveContent
+  );
+}
+
+export const SpreadsheetEditor = memo(PureSpreadsheetEditor, areEqual);

--- a/components/spreadsheet-editor.tsx
+++ b/components/spreadsheet-editor.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import React, { useEffect, useState, useRef, KeyboardEvent, useCallback, memo } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  KeyboardEvent,
+  useCallback,
+  memo,
+} from 'react';
 import { cn } from '@/lib/utils';
 import { ChevronDownIcon, PlusIcon, UploadIcon } from './icons';
 
@@ -27,13 +34,25 @@ const PureSpreadsheetEditor = ({
     try {
       const parsed = JSON.parse(content);
       return {
-        headers: Array.isArray(parsed.headers) ? parsed.headers : ['A', 'B', 'C'],
-        rows: Array.isArray(parsed.rows) ? parsed.rows.map((row: unknown) => 
-          Array.isArray(row) ? row.map(cell => String(cell || '')) : new Array(parsed.headers?.length || 3).fill('')
-        ) : [new Array(3).fill(''), new Array(3).fill('')]
+        headers: Array.isArray(parsed.headers)
+          ? parsed.headers
+          : ['A', 'B', 'C'],
+        rows: Array.isArray(parsed.rows)
+          ? parsed.rows.map((row: unknown) =>
+              Array.isArray(row)
+                ? row.map((cell) => String(cell || ''))
+                : new Array(parsed.headers?.length || 3).fill(''),
+            )
+          : [new Array(3).fill(''), new Array(3).fill('')],
       };
     } catch {
-      return { headers: ['A', 'B', 'C'], rows: [['', '', ''], ['', '', '']] };
+      return {
+        headers: ['A', 'B', 'C'],
+        rows: [
+          ['', '', ''],
+          ['', '', ''],
+        ],
+      };
     }
   });
 
@@ -42,12 +61,20 @@ const PureSpreadsheetEditor = ({
     try {
       const parsed = JSON.parse(newContent);
       if (parsed && typeof parsed === 'object') {
-        setData(prevData => {
+        setData((prevData) => {
           const newData = {
-            headers: Array.isArray(parsed.headers) ? parsed.headers.map((h: unknown) => String(h || '')) : prevData.headers,
-            rows: Array.isArray(parsed.rows) ? parsed.rows.map((row: unknown) => 
-              Array.isArray(row) ? row.map(cell => String(cell || '')) : new Array(parsed.headers?.length || prevData.headers.length).fill('')
-            ) : prevData.rows
+            headers: Array.isArray(parsed.headers)
+              ? parsed.headers.map((h: unknown) => String(h || ''))
+              : prevData.headers,
+            rows: Array.isArray(parsed.rows)
+              ? parsed.rows.map((row: unknown) =>
+                  Array.isArray(row)
+                    ? row.map((cell) => String(cell || ''))
+                    : new Array(
+                        parsed.headers?.length || prevData.headers.length,
+                      ).fill(''),
+                )
+              : prevData.rows,
           };
           // Normalize rows
           newData.rows = newData.rows.map((row: string[]) => {
@@ -68,9 +95,9 @@ const PureSpreadsheetEditor = ({
   useEffect(() => {
     const currentContent = JSON.stringify({
       headers: data.headers,
-      rows: data.rows
+      rows: data.rows,
     });
-    
+
     if (content && content !== currentContent) {
       handleContentUpdate(content);
     }
@@ -96,148 +123,174 @@ const PureSpreadsheetEditor = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Memoize cell and header change handlers
-  const handleHeaderChange = useCallback((index: number, value: string) => {
-    setData(prevData => {
-      const newData = {
-        headers: [...prevData.headers],
-        rows: [...prevData.rows]
-      };
-      newData.headers[index] = value;
-      saveContent(JSON.stringify(newData), true);
-      return newData;
-    });
-  }, [saveContent]);
+  const handleHeaderChange = useCallback(
+    (index: number, value: string) => {
+      setData((prevData) => {
+        const newData = {
+          headers: [...prevData.headers],
+          rows: [...prevData.rows],
+        };
+        newData.headers[index] = value;
+        saveContent(JSON.stringify(newData), true);
+        return newData;
+      });
+    },
+    [saveContent],
+  );
 
-  const handleCellChange = useCallback((rowIndex: number, colIndex: number, value: string) => {
-    setData(prevData => {
-      const newData = {
-        headers: [...prevData.headers],
-        rows: prevData.rows.map(row => [...row])
-      };
-      if (!newData.rows[rowIndex]) {
-        newData.rows[rowIndex] = [];
-      }
-      newData.rows[rowIndex][colIndex] = value;
-      saveContent(JSON.stringify(newData), true);
-      return newData;
-    });
-  }, [saveContent]);
-
-  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
-    if (!selectedCell) return;
-
-    const { row, col } = selectedCell;
-    let newRow = row;
-    let newCol = col;
-
-    switch (e.key) {
-      case 'ArrowUp':
-        newRow = Math.max(0, row - 1);
-        break;
-      case 'ArrowDown':
-        newRow = Math.min(data.rows.length - 1, row + 1);
-        break;
-      case 'ArrowLeft':
-        newCol = Math.max(0, col - 1);
-        break;
-      case 'ArrowRight':
-        newCol = Math.min(data.headers.length - 1, col + 1);
-        break;
-      case 'Enter':
-        if (!editingCell) {
-          setEditingCell({ row, col, value: data.rows[row][col] });
+  const handleCellChange = useCallback(
+    (rowIndex: number, colIndex: number, value: string) => {
+      setData((prevData) => {
+        const newData = {
+          headers: [...prevData.headers],
+          rows: prevData.rows.map((row) => [...row]),
+        };
+        if (!newData.rows[rowIndex]) {
+          newData.rows[rowIndex] = [];
         }
-        break;
-      case 'Escape':
+        newData.rows[rowIndex][colIndex] = value;
+        saveContent(JSON.stringify(newData), true);
+        return newData;
+      });
+    },
+    [saveContent],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (!selectedCell) return;
+
+      const { row, col } = selectedCell;
+      let newRow = row;
+      let newCol = col;
+
+      switch (e.key) {
+        case 'ArrowUp':
+          newRow = Math.max(0, row - 1);
+          break;
+        case 'ArrowDown':
+          newRow = Math.min(data.rows.length - 1, row + 1);
+          break;
+        case 'ArrowLeft':
+          newCol = Math.max(0, col - 1);
+          break;
+        case 'ArrowRight':
+          newCol = Math.min(data.headers.length - 1, col + 1);
+          break;
+        case 'Enter':
+          if (!editingCell) {
+            setEditingCell({ row, col, value: data.rows[row][col] });
+          }
+          break;
+        case 'Escape':
+          setEditingCell(null);
+          break;
+        default:
+          return;
+      }
+
+      if (newRow !== row || newCol !== col) {
+        e.preventDefault();
+        setSelectedCell({ row: newRow, col: newCol });
         setEditingCell(null);
-        break;
-      default:
-        return;
-    }
-
-    if (newRow !== row || newCol !== col) {
-      e.preventDefault();
-      setSelectedCell({ row: newRow, col: newCol });
-      setEditingCell(null);
-    }
-  }, [selectedCell, data.rows.length, data.headers.length, editingCell]);
-
-  const addColumn = useCallback((index?: number) => {
-    setData(prevData => {
-      const insertAt = typeof index === 'number' ? index : prevData.headers.length;
-      const newData = {
-        headers: [...prevData.headers],
-        rows: prevData.rows.map(row => [...row])
-      };
-      
-      // Generate next column name (A, B, C, ..., Z, AA, AB, ...)
-      const getNextColumnName = (n: number) => {
-        let name = '';
-        while (n >= 0) {
-          name = String.fromCharCode(65 + (n % 26)) + name;
-          n = Math.floor(n / 26) - 1;
-        }
-        return name;
-      };
-
-      newData.headers.splice(insertAt, 0, getNextColumnName(prevData.headers.length));
-      newData.rows.forEach(row => row.splice(insertAt, 0, ''));
-      
-      saveContent(JSON.stringify(newData), true);
-      return newData;
-    });
-  }, [saveContent]);
-
-  const deleteColumn = useCallback((index: number) => {
-    setData(prevData => {
-      if (prevData.headers.length <= 1) return prevData;
-
-      const newData = {
-        headers: [...prevData.headers],
-        rows: prevData.rows.map(row => [...row])
-      };
-
-      newData.headers.splice(index, 1);
-      newData.rows.forEach(row => row.splice(index, 1));
-      
-      saveContent(JSON.stringify(newData), true);
-      return newData;
-    });
-  }, [saveContent]);
-
-  const addRow = useCallback((index?: number) => {
-    setData(prevData => {
-      const newData = {
-        headers: [...prevData.headers],
-        rows: [...prevData.rows]
-      };
-      const newRow = new Array(prevData.headers.length).fill('');
-      
-      if (typeof index === 'number') {
-        newData.rows.splice(index, 0, newRow);
-      } else {
-        newData.rows.push(newRow);
       }
-      
-      saveContent(JSON.stringify(newData), true);
-      return newData;
-    });
-  }, [saveContent]);
+    },
+    [selectedCell, data.rows.length, data.headers.length, editingCell],
+  );
 
-  const deleteRow = useCallback((index: number) => {
-    setData(prevData => {
-      if (prevData.rows.length <= 1) return prevData;
+  const addColumn = useCallback(
+    (index?: number) => {
+      setData((prevData) => {
+        const insertAt =
+          typeof index === 'number' ? index : prevData.headers.length;
+        const newData = {
+          headers: [...prevData.headers],
+          rows: prevData.rows.map((row) => [...row]),
+        };
 
-      const newData = {
-        headers: [...prevData.headers],
-        rows: [...prevData.rows]
-      };
-      newData.rows.splice(index, 1);
-      
-      saveContent(JSON.stringify(newData), true);
-      return newData;
-    });
-  }, [saveContent]);
+        // Generate next column name (A, B, C, ..., Z, AA, AB, ...)
+        const getNextColumnName = (n: number) => {
+          let name = '';
+          while (n >= 0) {
+            name = String.fromCharCode(65 + (n % 26)) + name;
+            n = Math.floor(n / 26) - 1;
+          }
+          return name;
+        };
+
+        newData.headers.splice(
+          insertAt,
+          0,
+          getNextColumnName(prevData.headers.length),
+        );
+        newData.rows.forEach((row) => row.splice(insertAt, 0, ''));
+
+        saveContent(JSON.stringify(newData), true);
+        return newData;
+      });
+    },
+    [saveContent],
+  );
+
+  const deleteColumn = useCallback(
+    (index: number) => {
+      setData((prevData) => {
+        if (prevData.headers.length <= 1) return prevData;
+
+        const newData = {
+          headers: [...prevData.headers],
+          rows: prevData.rows.map((row) => [...row]),
+        };
+
+        newData.headers.splice(index, 1);
+        newData.rows.forEach((row) => row.splice(index, 1));
+
+        saveContent(JSON.stringify(newData), true);
+        return newData;
+      });
+    },
+    [saveContent],
+  );
+
+  const addRow = useCallback(
+    (index?: number) => {
+      setData((prevData) => {
+        const newData = {
+          headers: [...prevData.headers],
+          rows: [...prevData.rows],
+        };
+        const newRow = new Array(prevData.headers.length).fill('');
+
+        if (typeof index === 'number') {
+          newData.rows.splice(index, 0, newRow);
+        } else {
+          newData.rows.push(newRow);
+        }
+
+        saveContent(JSON.stringify(newData), true);
+        return newData;
+      });
+    },
+    [saveContent],
+  );
+
+  const deleteRow = useCallback(
+    (index: number) => {
+      setData((prevData) => {
+        if (prevData.rows.length <= 1) return prevData;
+
+        const newData = {
+          headers: [...prevData.headers],
+          rows: [...prevData.rows],
+        };
+        newData.rows.splice(index, 1);
+
+        saveContent(JSON.stringify(newData), true);
+        return newData;
+      });
+    },
+    [saveContent],
+  );
 
   if (!isCurrentVersion || status === 'streaming') {
     return (
@@ -273,7 +326,7 @@ const PureSpreadsheetEditor = ({
   }
 
   return (
-    <div 
+    <div
       className="w-full overflow-x-auto"
       ref={editorRef}
       tabIndex={0}
@@ -284,12 +337,12 @@ const PureSpreadsheetEditor = ({
           <tr>
             <th className="w-10 bg-muted border p-2"></th>
             {data.headers.map((header, i) => (
-              <th 
-                key={i} 
+              <th
+                key={i}
                 className={cn(
-                  "border p-2 bg-muted min-w-[100px] relative group",
-                  hoveredColumn === i && "bg-muted/80",
-                  "hover:cursor-pointer"
+                  'border p-2 bg-muted min-w-[100px] relative group',
+                  hoveredColumn === i && 'bg-muted/80',
+                  'hover:cursor-pointer',
                 )}
                 onMouseEnter={() => setHoveredColumn(i)}
                 onMouseLeave={() => setHoveredColumn(null)}
@@ -324,19 +377,28 @@ const PureSpreadsheetEditor = ({
                 {showColumnMenu === i && (
                   <div className="absolute top-full left-0 mt-1 w-40 bg-popover border rounded-md shadow-md z-10">
                     <button
-                      onClick={() => { addColumn(i); setShowColumnMenu(null); }}
+                      onClick={() => {
+                        addColumn(i);
+                        setShowColumnMenu(null);
+                      }}
                       className="w-full px-3 py-2 text-left hover:bg-muted"
                     >
                       Insert column left
                     </button>
                     <button
-                      onClick={() => { addColumn(i + 1); setShowColumnMenu(null); }}
+                      onClick={() => {
+                        addColumn(i + 1);
+                        setShowColumnMenu(null);
+                      }}
                       className="w-full px-3 py-2 text-left hover:bg-muted"
                     >
                       Insert column right
                     </button>
                     <button
-                      onClick={() => { deleteColumn(i); setShowColumnMenu(null); }}
+                      onClick={() => {
+                        deleteColumn(i);
+                        setShowColumnMenu(null);
+                      }}
                       className="w-full px-3 py-2 text-left hover:bg-muted text-destructive"
                     >
                       Delete column
@@ -358,9 +420,9 @@ const PureSpreadsheetEditor = ({
         </thead>
         <tbody>
           {data.rows.map((row, rowIndex) => (
-            <tr 
+            <tr
               key={rowIndex}
-              className={cn(hoveredRow === rowIndex && "bg-muted/5")}
+              className={cn(hoveredRow === rowIndex && 'bg-muted/5')}
               onMouseEnter={() => setHoveredRow(rowIndex)}
               onMouseLeave={() => setHoveredRow(null)}
             >
@@ -368,7 +430,9 @@ const PureSpreadsheetEditor = ({
                 <div className="flex items-center justify-between">
                   <span>{rowIndex + 1}</span>
                   <button
-                    onClick={() => setShowRowMenu(showRowMenu === rowIndex ? null : rowIndex)}
+                    onClick={() =>
+                      setShowRowMenu(showRowMenu === rowIndex ? null : rowIndex)
+                    }
                     className="opacity-0 group-hover:opacity-100 transition-opacity"
                   >
                     <ChevronDownIcon size={16} />
@@ -377,19 +441,28 @@ const PureSpreadsheetEditor = ({
                 {showRowMenu === rowIndex && (
                   <div className="absolute top-0 left-full ml-1 w-40 bg-popover border rounded-md shadow-md z-10">
                     <button
-                      onClick={() => { addRow(rowIndex); setShowRowMenu(null); }}
+                      onClick={() => {
+                        addRow(rowIndex);
+                        setShowRowMenu(null);
+                      }}
                       className="w-full px-3 py-2 text-left hover:bg-muted"
                     >
                       Insert row above
                     </button>
                     <button
-                      onClick={() => { addRow(rowIndex + 1); setShowRowMenu(null); }}
+                      onClick={() => {
+                        addRow(rowIndex + 1);
+                        setShowRowMenu(null);
+                      }}
                       className="w-full px-3 py-2 text-left hover:bg-muted"
                     >
                       Insert row below
                     </button>
                     <button
-                      onClick={() => { deleteRow(rowIndex); setShowRowMenu(null); }}
+                      onClick={() => {
+                        deleteRow(rowIndex);
+                        setShowRowMenu(null);
+                      }}
                       className="w-full px-3 py-2 text-left hover:bg-muted text-destructive"
                     >
                       Delete row
@@ -398,29 +471,35 @@ const PureSpreadsheetEditor = ({
                 )}
               </td>
               {row.map((cell, colIndex) => (
-                <td 
-                  key={colIndex} 
+                <td
+                  key={colIndex}
                   className={cn(
-                    "border p-2 min-w-[100px] relative select-none",
-                    hoveredColumn === colIndex && "bg-muted/5",
-                    selectedCell?.row === rowIndex && selectedCell?.col === colIndex && [
-                      "before:absolute before:inset-[-1px] before:pointer-events-none", 
-                      "before:border-2 before:border-primary before:rounded-sm",
-                      "before:origin-center before:transition-all before:duration-200",
-                      "before:animate-in before:fade-in-0 before:zoom-in-[0.98]",
-                      "after:absolute after:inset-[-1px] after:pointer-events-none",
-                      "after:border-2 after:border-primary/20 after:rounded-sm", 
-                      "after:origin-center after:transition-all after:duration-300",
-                      "after:animate-in after:fade-in-0 after:zoom-in-[1] after:delay-75",
-                      "after:scale-[1.005]"
-                    ]
+                    'border p-2 min-w-[100px] relative select-none',
+                    hoveredColumn === colIndex && 'bg-muted/5',
+                    selectedCell?.row === rowIndex &&
+                      selectedCell?.col === colIndex && [
+                        'before:absolute before:inset-[-1px] before:pointer-events-none',
+                        'before:border-2 before:border-primary before:rounded-sm',
+                        'before:origin-center before:transition-all before:duration-200',
+                        'before:animate-in before:fade-in-0 before:zoom-in-[0.98]',
+                        'after:absolute after:inset-[-1px] after:pointer-events-none',
+                        'after:border-2 after:border-primary/20 after:rounded-sm',
+                        'after:origin-center after:transition-all after:duration-300',
+                        'after:animate-in after:fade-in-0 after:zoom-in-[1] after:delay-75',
+                        'after:scale-[1.005]',
+                      ],
                   )}
                   onClick={() => {
                     setSelectedCell({ row: rowIndex, col: colIndex });
-                    setEditingCell({ row: rowIndex, col: colIndex, value: cell });
+                    setEditingCell({
+                      row: rowIndex,
+                      col: colIndex,
+                      value: cell,
+                    });
                   }}
                 >
-                  {editingCell?.row === rowIndex && editingCell?.col === colIndex ? (
+                  {editingCell?.row === rowIndex &&
+                  editingCell?.col === colIndex ? (
                     <input
                       ref={inputRef}
                       type="text"
@@ -438,18 +517,28 @@ const PureSpreadsheetEditor = ({
                       onKeyDown={(e) => {
                         if (e.key === 'Enter') {
                           e.preventDefault();
-                          handleCellChange(rowIndex, colIndex, editingCell.value);
+                          handleCellChange(
+                            rowIndex,
+                            colIndex,
+                            editingCell.value,
+                          );
                           setEditingCell(null);
                           setSelectedCell({ row: rowIndex + 1, col: colIndex });
                         } else if (e.key === 'Escape') {
                           setEditingCell(null);
                         } else if (e.key === 'Tab') {
                           e.preventDefault();
-                          handleCellChange(rowIndex, colIndex, editingCell.value);
+                          handleCellChange(
+                            rowIndex,
+                            colIndex,
+                            editingCell.value,
+                          );
                           setEditingCell(null);
-                          setSelectedCell({ 
-                            row: rowIndex, 
-                            col: e.shiftKey ? Math.max(0, colIndex - 1) : Math.min(data.headers.length - 1, colIndex + 1) 
+                          setSelectedCell({
+                            row: rowIndex,
+                            col: e.shiftKey
+                              ? Math.max(0, colIndex - 1)
+                              : Math.min(data.headers.length - 1, colIndex + 1),
                           });
                         }
                       }}
@@ -457,9 +546,7 @@ const PureSpreadsheetEditor = ({
                       autoFocus
                     />
                   ) : (
-                    <div className="min-h-[1.5rem]">
-                      {cell}
-                    </div>
+                    <div className="min-h-[1.5rem]">{cell}</div>
                   )}
                 </td>
               ))}
@@ -493,9 +580,12 @@ const PureSpreadsheetEditor = ({
       </table>
     </div>
   );
-}
+};
 
-function areEqual(prevProps: SpreadsheetEditorProps, nextProps: SpreadsheetEditorProps) {
+function areEqual(
+  prevProps: SpreadsheetEditorProps,
+  nextProps: SpreadsheetEditorProps,
+) {
   return (
     prevProps.currentVersionIndex === nextProps.currentVersionIndex &&
     prevProps.isCurrentVersion === nextProps.isCurrentVersion &&

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -33,6 +33,7 @@ import {
   LogsIcon,
   MessageIcon,
   PenIcon,
+  SparklesIcon,
   StopIcon,
   SummarizeIcon,
   TerminalIcon,
@@ -327,6 +328,18 @@ const toolsByBlockKind: Record<
       icon: <LogsIcon />,
     },
   ],
+  spreadsheet: [
+    {
+      type: 'final-polish',
+      description: 'Format and clean data',
+      icon: <SparklesIcon />,
+    },
+    {
+      type: 'request-suggestions',
+      description: 'Analyze and visualize data',
+      icon: <MessageIcon />,
+    },
+  ],
 };
 
 export const Tools = ({
@@ -347,7 +360,7 @@ export const Tools = ({
   ) => Promise<string | null | undefined>;
   isAnimating: boolean;
   setIsToolbarVisible: Dispatch<SetStateAction<boolean>>;
-  blockKind: 'text' | 'code';
+  blockKind: BlockKind;
 }) => {
   const [primaryTool, ...secondaryTools] = toolsByBlockKind[blockKind];
 
@@ -407,7 +420,7 @@ const PureToolbar = ({
   ) => Promise<string | null | undefined>;
   stop: () => void;
   setMessages: Dispatch<SetStateAction<Message[]>>;
-  blockKind: 'text' | 'code';
+  blockKind: BlockKind;
 }) => {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();

--- a/lib/db/migrations/0005_kind_sheet.sql
+++ b/lib/db/migrations/0005_kind_sheet.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Document" ADD COLUMN "kind" varchar DEFAULT 'text' NOT NULL;--> statement-breakpoint
+ALTER TABLE "Document" DROP COLUMN IF EXISTS "text";

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,5 +1,5 @@
-import { BLOCK_KINDS } from "@/components/block";
-import type { InferSelectModel } from "drizzle-orm";
+import { BLOCK_KINDS } from '@/components/block';
+import type { InferSelectModel } from 'drizzle-orm';
 import {
   pgTable,
   varchar,
@@ -10,73 +10,73 @@ import {
   primaryKey,
   foreignKey,
   boolean,
-} from "drizzle-orm/pg-core";
+} from 'drizzle-orm/pg-core';
 
-export const user = pgTable("User", {
-  id: uuid("id").primaryKey().notNull().defaultRandom(),
-  email: varchar("email", { length: 64 }).notNull(),
-  password: varchar("password", { length: 64 }),
+export const user = pgTable('User', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  email: varchar('email', { length: 64 }).notNull(),
+  password: varchar('password', { length: 64 }),
 });
 
 export type User = InferSelectModel<typeof user>;
 
-export const chat = pgTable("Chat", {
-  id: uuid("id").primaryKey().notNull().defaultRandom(),
-  createdAt: timestamp("createdAt").notNull(),
-  title: text("title").notNull(),
-  userId: uuid("userId")
+export const chat = pgTable('Chat', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  createdAt: timestamp('createdAt').notNull(),
+  title: text('title').notNull(),
+  userId: uuid('userId')
     .notNull()
     .references(() => user.id),
-  visibility: varchar("visibility", { enum: ["public", "private"] })
+  visibility: varchar('visibility', { enum: ['public', 'private'] })
     .notNull()
-    .default("private"),
+    .default('private'),
 });
 
 export type Chat = InferSelectModel<typeof chat>;
 
-export const message = pgTable("Message", {
-  id: uuid("id").primaryKey().notNull().defaultRandom(),
-  chatId: uuid("chatId")
+export const message = pgTable('Message', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  chatId: uuid('chatId')
     .notNull()
     .references(() => chat.id),
-  role: varchar("role").notNull(),
-  content: json("content").notNull(),
-  createdAt: timestamp("createdAt").notNull(),
+  role: varchar('role').notNull(),
+  content: json('content').notNull(),
+  createdAt: timestamp('createdAt').notNull(),
 });
 
 export type Message = InferSelectModel<typeof message>;
 
 export const vote = pgTable(
-  "Vote",
+  'Vote',
   {
-    chatId: uuid("chatId")
+    chatId: uuid('chatId')
       .notNull()
       .references(() => chat.id),
-    messageId: uuid("messageId")
+    messageId: uuid('messageId')
       .notNull()
       .references(() => message.id),
-    isUpvoted: boolean("isUpvoted").notNull(),
+    isUpvoted: boolean('isUpvoted').notNull(),
   },
   (table) => {
     return {
       pk: primaryKey({ columns: [table.chatId, table.messageId] }),
     };
-  }
+  },
 );
 
 export type Vote = InferSelectModel<typeof vote>;
 
 export const document = pgTable(
-  "Document",
+  'Document',
   {
-    id: uuid("id").notNull().defaultRandom(),
-    createdAt: timestamp("createdAt").notNull(),
-    title: text("title").notNull(),
-    content: text("content"),
-    kind: varchar("kind", { enum: ["text", "code", "spreadsheet"] })
+    id: uuid('id').notNull().defaultRandom(),
+    createdAt: timestamp('createdAt').notNull(),
+    title: text('title').notNull(),
+    content: text('content'),
+    kind: varchar('kind', { enum: ['text', 'code', 'spreadsheet'] })
       .notNull()
-      .default("text"),
-    userId: uuid("userId")
+      .default('text'),
+    userId: uuid('userId')
       .notNull()
       .references(() => user.id),
   },
@@ -84,25 +84,25 @@ export const document = pgTable(
     return {
       pk: primaryKey({ columns: [table.id, table.createdAt] }),
     };
-  }
+  },
 );
 
 export type Document = InferSelectModel<typeof document>;
 
 export const suggestion = pgTable(
-  "Suggestion",
+  'Suggestion',
   {
-    id: uuid("id").notNull().defaultRandom(),
-    documentId: uuid("documentId").notNull(),
-    documentCreatedAt: timestamp("documentCreatedAt").notNull(),
-    originalText: text("originalText").notNull(),
-    suggestedText: text("suggestedText").notNull(),
-    description: text("description"),
-    isResolved: boolean("isResolved").notNull().default(false),
-    userId: uuid("userId")
+    id: uuid('id').notNull().defaultRandom(),
+    documentId: uuid('documentId').notNull(),
+    documentCreatedAt: timestamp('documentCreatedAt').notNull(),
+    originalText: text('originalText').notNull(),
+    suggestedText: text('suggestedText').notNull(),
+    description: text('description'),
+    isResolved: boolean('isResolved').notNull().default(false),
+    userId: uuid('userId')
       .notNull()
       .references(() => user.id),
-    createdAt: timestamp("createdAt").notNull(),
+    createdAt: timestamp('createdAt').notNull(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.id] }),
@@ -110,7 +110,7 @@ export const suggestion = pgTable(
       columns: [table.documentId, table.documentCreatedAt],
       foreignColumns: [document.id, document.createdAt],
     }),
-  })
+  }),
 );
 
 export type Suggestion = InferSelectModel<typeof suggestion>;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,4 +1,5 @@
-import type { InferSelectModel } from 'drizzle-orm';
+import { BLOCK_KINDS } from "@/components/block";
+import type { InferSelectModel } from "drizzle-orm";
 import {
   pgTable,
   varchar,
@@ -9,73 +10,73 @@ import {
   primaryKey,
   foreignKey,
   boolean,
-} from 'drizzle-orm/pg-core';
+} from "drizzle-orm/pg-core";
 
-export const user = pgTable('User', {
-  id: uuid('id').primaryKey().notNull().defaultRandom(),
-  email: varchar('email', { length: 64 }).notNull(),
-  password: varchar('password', { length: 64 }),
+export const user = pgTable("User", {
+  id: uuid("id").primaryKey().notNull().defaultRandom(),
+  email: varchar("email", { length: 64 }).notNull(),
+  password: varchar("password", { length: 64 }),
 });
 
 export type User = InferSelectModel<typeof user>;
 
-export const chat = pgTable('Chat', {
-  id: uuid('id').primaryKey().notNull().defaultRandom(),
-  createdAt: timestamp('createdAt').notNull(),
-  title: text('title').notNull(),
-  userId: uuid('userId')
+export const chat = pgTable("Chat", {
+  id: uuid("id").primaryKey().notNull().defaultRandom(),
+  createdAt: timestamp("createdAt").notNull(),
+  title: text("title").notNull(),
+  userId: uuid("userId")
     .notNull()
     .references(() => user.id),
-  visibility: varchar('visibility', { enum: ['public', 'private'] })
+  visibility: varchar("visibility", { enum: ["public", "private"] })
     .notNull()
-    .default('private'),
+    .default("private"),
 });
 
 export type Chat = InferSelectModel<typeof chat>;
 
-export const message = pgTable('Message', {
-  id: uuid('id').primaryKey().notNull().defaultRandom(),
-  chatId: uuid('chatId')
+export const message = pgTable("Message", {
+  id: uuid("id").primaryKey().notNull().defaultRandom(),
+  chatId: uuid("chatId")
     .notNull()
     .references(() => chat.id),
-  role: varchar('role').notNull(),
-  content: json('content').notNull(),
-  createdAt: timestamp('createdAt').notNull(),
+  role: varchar("role").notNull(),
+  content: json("content").notNull(),
+  createdAt: timestamp("createdAt").notNull(),
 });
 
 export type Message = InferSelectModel<typeof message>;
 
 export const vote = pgTable(
-  'Vote',
+  "Vote",
   {
-    chatId: uuid('chatId')
+    chatId: uuid("chatId")
       .notNull()
       .references(() => chat.id),
-    messageId: uuid('messageId')
+    messageId: uuid("messageId")
       .notNull()
       .references(() => message.id),
-    isUpvoted: boolean('isUpvoted').notNull(),
+    isUpvoted: boolean("isUpvoted").notNull(),
   },
   (table) => {
     return {
       pk: primaryKey({ columns: [table.chatId, table.messageId] }),
     };
-  },
+  }
 );
 
 export type Vote = InferSelectModel<typeof vote>;
 
 export const document = pgTable(
-  'Document',
+  "Document",
   {
-    id: uuid('id').notNull().defaultRandom(),
-    createdAt: timestamp('createdAt').notNull(),
-    title: text('title').notNull(),
-    content: text('content'),
-    kind: varchar('text', { enum: ['text', 'code'] })
+    id: uuid("id").notNull().defaultRandom(),
+    createdAt: timestamp("createdAt").notNull(),
+    title: text("title").notNull(),
+    content: text("content"),
+    kind: varchar("kind", { enum: ["text", "code", "spreadsheet"] })
       .notNull()
-      .default('text'),
-    userId: uuid('userId')
+      .default("text"),
+    userId: uuid("userId")
       .notNull()
       .references(() => user.id),
   },
@@ -83,25 +84,25 @@ export const document = pgTable(
     return {
       pk: primaryKey({ columns: [table.id, table.createdAt] }),
     };
-  },
+  }
 );
 
 export type Document = InferSelectModel<typeof document>;
 
 export const suggestion = pgTable(
-  'Suggestion',
+  "Suggestion",
   {
-    id: uuid('id').notNull().defaultRandom(),
-    documentId: uuid('documentId').notNull(),
-    documentCreatedAt: timestamp('documentCreatedAt').notNull(),
-    originalText: text('originalText').notNull(),
-    suggestedText: text('suggestedText').notNull(),
-    description: text('description'),
-    isResolved: boolean('isResolved').notNull().default(false),
-    userId: uuid('userId')
+    id: uuid("id").notNull().defaultRandom(),
+    documentId: uuid("documentId").notNull(),
+    documentCreatedAt: timestamp("documentCreatedAt").notNull(),
+    originalText: text("originalText").notNull(),
+    suggestedText: text("suggestedText").notNull(),
+    description: text("description"),
+    isResolved: boolean("isResolved").notNull().default(false),
+    userId: uuid("userId")
       .notNull()
       .references(() => user.id),
-    createdAt: timestamp('createdAt').notNull(),
+    createdAt: timestamp("createdAt").notNull(),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.id] }),
@@ -109,7 +110,7 @@ export const suggestion = pgTable(
       columns: [table.documentId, table.documentCreatedAt],
       foreignColumns: [document.id, document.createdAt],
     }),
-  }),
+  })
 );
 
 export type Suggestion = InferSelectModel<typeof suggestion>;

--- a/lib/spreadsheet.ts
+++ b/lib/spreadsheet.ts
@@ -1,0 +1,54 @@
+interface SpreadsheetData {
+  headers: string[];
+  rows: string[][];
+}
+
+export function exportToCSV(
+  content: string,
+  filename = 'spreadsheet.csv',
+): void {
+  try {
+    const data = JSON.parse(content) as SpreadsheetData;
+    if (!data?.headers || !data?.rows) {
+      throw new Error('Invalid spreadsheet data');
+    }
+
+    // Normalize rows to ensure they have the same length as headers
+    const normalizedRows = data.rows.map((row) => {
+      const normalizedRow = [...row];
+      while (normalizedRow.length < data.headers.length) {
+        normalizedRow.push('');
+      }
+      return normalizedRow;
+    });
+
+    // Create CSV content
+    const csvContent = [
+      data.headers.join(','),
+      ...normalizedRows.map((row) =>
+        row
+          .map((cell) => {
+            // Escape quotes and wrap in quotes if contains comma or quotes
+            const escaped = String(cell || '').replace(/"/g, '""');
+            return escaped.includes(',') || escaped.includes('"')
+              ? `"${escaped}"`
+              : escaped;
+          })
+          .join(','),
+      ),
+    ].join('\n');
+
+    // Create and trigger download
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    return;
+  } catch (error) {
+    throw new Error('Failed to export CSV: ' + (error as Error).message);
+  }
+}


### PR DESCRIPTION
**WIP - feedback + improvements are very welcomed!**

## Adds Spreadsheet support to the canvas
- Adds interactive sheet functionality to the AI chat interface, allowing users to:
  - Use AI to generate and manipulate spreadsheet content
  - Create and edit tabular data
  - Export data to CSV format
  - Navigate cells using keyboard shortcuts
  - Add/remove rows and columns

Known Issues:
- There are still some rendering/layout shifting issues with the custom spreadsheet component (wip)
- Still need to nail the cell clicking+highlighting animation/ux
- Editing cells and moving throughout the spreadsheet is not very smooth
- Light mode only currently

Little Demo:
https://github.com/user-attachments/assets/f9765138-5962-43ab-9156-e1c93b4a2423


Posts and examples for reference below:

[https://x.com/nickscamara_/status/1874849831052890175](https://x.com/nickscamara_/status/1874849831052890175)
[https://x.com/nickscamara_/status/1876675517694328834](https://x.com/nickscamara_/status/1876675517694328834)


Thanks @jaredpalmer for suggesting me to open a PR for this.