### PR TITLE
 include createdAt for chatMessages

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -120,6 +120,7 @@ export function convertToUIMessages(
       role: message.role as Message['role'],
       content: textContent,
       toolInvocations,
+      createdAt: message.createdAt ? new Date(message.createdAt) : undefined,
     });
 
     return chatMessages;


### PR DESCRIPTION
"createdAt" per message is currently missing in the chatMessages array.

this simply includes it so that it the timestamp can we shown next to each message if one so wishes.