### PR TITLE
fix: hide left border around canvas when resized

### DIFF
--- a/components/block.tsx
+++ b/components/block.tsx
@@ -358,7 +358,7 @@ function PureBlock({
           )}
 
           <motion.div
-            className="fixed dark:bg-muted bg-background h-dvh flex flex-col overflow-y-scroll border-l dark:border-zinc-700 border-zinc-200"
+            className="fixed dark:bg-muted bg-background h-dvh flex flex-col overflow-y-scroll md:border-l dark:border-zinc-700 border-zinc-200"
             initial={
               isMobile
                 ? {


### PR DESCRIPTION
This pull request removes the left border around canvas when resized to accommodate smaller screens.