### PR TITLE
Add necessary DB migration step for localhost instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,18 @@ You will need to use the environment variables [defined in `.env.example`](.env.
 
 1. Install Vercel CLI: `npm i -g vercel`
 2. Link local instance with Vercel and GitHub accounts (creates `.vercel` directory): `vercel link`
+
+> Alternatively, set the environment variables from Vercel (without linking to a project.)
+
 3. Download your environment variables: `vercel env pull`
 
 ```bash
 pnpm install
+pnpm tsx lib/db/migrate.ts && pnpm run build
+```
+
+4. Start the development server:
+```bash
 pnpm dev
 ```
 


### PR DESCRIPTION
## Summary
This PR adds an explicit database migration step to the local setup instructions. This is necessary because without running migration - you **will** get DB errors without doing so.

## Changes
Updates the "Running locally" section of the README to include the database migration step:

```diff
- pnpm install
- pnpm dev
+ pnpm install
+ pnpm tsx lib/db/migrate.ts && pnpm run build
+ pnpm dev
```

## Why this is necessary
1. On local deployment, the database schema needs to be initialized before authentication can work
2. If not, you get authentication failures on first setup (#450, #731)

## Testing Done
- [x] Verified fresh setup works with these instructions
- [x] Confirmed authentication works after following updated steps

Closes #450
