### PR TITLE
fix: run block initialize fn only once

### DIFF
--- a/blocks/actions.ts
+++ b/blocks/actions.ts
@@ -4,5 +4,5 @@ import { getSuggestionsByDocumentId } from '@/lib/db/queries';
 
 export async function getSuggestions({ documentId }: { documentId: string }) {
   const suggestions = await getSuggestionsByDocumentId({ documentId });
-  return suggestions;
+  return suggestions ?? [];
 }

--- a/components/block.tsx
+++ b/components/block.tsx
@@ -249,7 +249,7 @@ function PureBlock({
   }
 
   useEffect(() => {
-    if (block && block.documentId !== 'init') {
+    if (block.documentId !== 'init') {
       if (blockDefinition.initialize) {
         blockDefinition.initialize({
           documentId: block.documentId,
@@ -257,7 +257,7 @@ function PureBlock({
         });
       }
     }
-  }, [block, blockDefinition, setMetadata]);
+  }, [block.documentId, blockDefinition, setMetadata]);
 
   return (
     <AnimatePresence>


### PR DESCRIPTION
This pull request fixes the block's initialize function being called several times during stream.