### PR TITLE
fix: update chat title if user edits first message

### DIFF
--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -146,6 +146,7 @@ const PureChatItem = ({
 
 export const ChatItem = memo(PureChatItem, (prevProps, nextProps) => {
   if (prevProps.isActive !== nextProps.isActive) return false;
+  if (prevProps.chat.title !== nextProps.chat.title) return false;
   return true;
 });
 

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -345,3 +345,18 @@ export async function updateChatVisiblityById({
     throw error;
   }
 }
+
+export async function updateChatTitleById({
+  id,
+  title,
+}: {
+  id: string;
+  title: string;
+}): Promise<void> {
+  try {
+    await db.update(chat).set({ title }).where(eq(chat.id, id));
+  } catch (error) {
+    console.error('Failed to update chat title in database');
+    throw error;
+  }
+}


### PR DESCRIPTION
Here is an overview of how it functions once this fix is applied:

![update_title](https://github.com/user-attachments/assets/2cbaa44d-9f6c-432d-af41-1b2469a5bfad)
