### PR TITLE
feat: allow to delete attachment

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -188,10 +188,17 @@ function PureMultimodalInput({
         console.error('Error uploading files!', error);
       } finally {
         setUploadQueue([]);
+        // Clear the file input to allow to select the same file again
+        event.target.value = '';
       }
     },
     [setAttachments],
   );
+
+  const handleDeleteAttachmentClick = (attachment: Attachment) =>
+    setAttachments((currentAttachments) =>
+      currentAttachments.filter((a) => a.url !== attachment.url),
+    );
 
   return (
     <div className="relative w-full flex flex-col gap-4">
@@ -203,17 +210,22 @@ function PureMultimodalInput({
 
       <input
         type="file"
-        className="fixed -top-4 -left-4 size-0.5 opacity-0 pointer-events-none"
+        className="hidden"
         ref={fileInputRef}
+        accept="image/png, image/jpeg"
         multiple
         onChange={handleFileChange}
         tabIndex={-1}
       />
 
       {(attachments.length > 0 || uploadQueue.length > 0) && (
-        <div className="flex flex-row gap-2 overflow-x-scroll items-end">
+        <div className="flex flex-row gap-2 items-end">
           {attachments.map((attachment) => (
-            <PreviewAttachment key={attachment.url} attachment={attachment} />
+            <PreviewAttachment
+              onDelete={handleDeleteAttachmentClick}
+              key={attachment.url}
+              attachment={attachment}
+            />
           ))}
 
           {uploadQueue.map((filename) => (

--- a/components/preview-attachment.tsx
+++ b/components/preview-attachment.tsx
@@ -1,13 +1,17 @@
 import type { Attachment } from 'ai';
+import { X } from 'lucide-react';
 
 import { LoaderIcon } from './icons';
+import { Button } from './ui/button';
 
 export const PreviewAttachment = ({
   attachment,
   isUploading = false,
+  onDelete,
 }: {
   attachment: Attachment;
   isUploading?: boolean;
+  onDelete?: (attachment: Attachment) => void;
 }) => {
   const { name, url, contentType } = attachment;
 
@@ -36,8 +40,23 @@ export const PreviewAttachment = ({
             <LoaderIcon />
           </div>
         )}
+
+        {onDelete && (
+          <Button
+            variant="outline"
+            onClick={() => onDelete(attachment)}
+            className="absolute -right-2 -top-2 rounded-full bg-background border p-0.5 hover:bg-muted size-6"
+          >
+            <X size={24} />
+          </Button>
+        )}
       </div>
-      <div className="text-xs text-zinc-500 max-w-16 truncate">{name}</div>
+      <div
+        title={name}
+        className="text-sm texs text-zinc-500 max-w-16 truncate"
+      >
+        {name}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
- I'm also limiting the file input to accept PNG or JPEG, as that's what the `/upload` route supports.


https://github.com/user-attachments/assets/ab7cc71b-e267-4647-8ae1-be92872875b5

The only reason why I'm opening it as a draft PR is that I can't figure out why negative classes are not working in Tailwind...
```
-right-2 -top-2
```