### PR TITLE
fix: accept only jpeg/png in file input

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -206,6 +206,7 @@ function PureMultimodalInput({
         className="fixed -top-4 -left-4 size-0.5 opacity-0 pointer-events-none"
         ref={fileInputRef}
         multiple
+        accept="image/jpeg,image/png"
         onChange={handleFileChange}
         tabIndex={-1}
       />


### PR DESCRIPTION
Add file type restrictions in native file picker

## What's Changed
- Added `accept="image/jpeg,image/png"` attribute to file input to show supported formats in the native file picker dialog

## Why?
- Improves user experience by showing only JPEG and PNG files in the file picker dialog
- Provides clear visual feedback about supported file types before upload attempt
- Reduces confusion about supported file types (prevents users from attempting to upload PDFs or other formats)
- Complements existing backend validation with frontend guidance

## Testing
- Verified file picker dialog only shows image files (JPEG, PNG) on both desktop and mobile browsers
- Confirmed backend validation still works as a security measure