### PR TITLE
fix: handle IME composition to prevent unintended submissions (#785)

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -242,7 +242,7 @@ function PureMultimodalInput({
         rows={2}
         autoFocus
         onKeyDown={(event) => {
-          if (event.key === 'Enter' && !event.shiftKey) {
+          if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
             event.preventDefault();
 
             if (isLoading) {


### PR DESCRIPTION
#### Summary:
This PR fixes the IME composition error (#785) that causes the chat input field to retain the last word when submitting messages using an IME for languages such as Chinese, Korean, and Japanese. The error occurs because the Enter key event is processed while text composition is still in progress.

#### Issue Details:
When using an IME (for example, for Chinese, Korean, or Japanese input), text composition occurs in stages. The original submission condition was:

```typescript
if (event.key === 'Enter' && !event.shiftKey)
```

This condition did not account for active text composition. As a result, pressing Enter during composition immediately processes the event, leaving the final composed word in the input field.

#### Fix:
The submission condition has been updated to include a check for ongoing text composition. The new condition is

```typescript
if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing)
```

This fix specifically addresses the IME composition error, and it should improve the behavior for other languages that rely on similar input methods.