### PR TITLE
feat: Enhance chat input area – scrolling & button overlap fix

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -236,7 +236,7 @@ function PureMultimodalInput({
         value={input}
         onChange={handleInput}
         className={cx(
-          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base bg-muted pb-10 dark:border-zinc-700',
+          'scroll-pb-10 min-h-[24px] max-h-[calc(75dvh)] overflow-y-auto resize-none rounded-2xl !text-base bg-muted pb-10 dark:border-zinc-700',
           className,
         )}
         rows={2}


### PR DESCRIPTION
### PR Description
- Replaced overflow-hidden with overflow-y-auto in the chat input field to enable vertical scrolling for lengthy messages.
- Added scroll-pb-10 to prevent the last line of text from overlapping with the file attachment and send buttons.

Improves the overall usability of the chat input area when composing messages.

#### Before
![before](https://github.com/user-attachments/assets/c498e51c-7650-4fa9-bc0e-70e9f8fa88ff)
#### After
![after](https://github.com/user-attachments/assets/6bcea611-aa45-4c52-b647-c3794a982120)

