### PR TITLE
fix: fix typing Chinese kind of languages #785

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -242,7 +242,7 @@ function PureMultimodalInput({
         rows={2}
         autoFocus
         onKeyDown={(event) => {
-          if (event.key === 'Enter' && !event.shiftKey) {
+          if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
             event.preventDefault();
 
             if (isLoading) {


### PR DESCRIPTION
Fix issue #785

fix: prevent Enter key from submitting form during Chinese composition

Added `!event.nativeEvent.isComposing` to the Enter key condition to avoid form submission while composing Chinese or other IME-based languages.