### PR TITLE
Compatible with IME

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -67,6 +67,7 @@ function PureMultimodalInput({
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
+  const [isTyping, setIsTyping] = useState(false);
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -245,6 +246,10 @@ function PureMultimodalInput({
           if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
 
+            if (isTyping) {
+              return;
+            }
+
             if (isLoading) {
               toast.error('Please wait for the model to finish its response!');
             } else {
@@ -252,6 +257,8 @@ function PureMultimodalInput({
             }
           }
         }}
+        onCompositionStart={() => setIsTyping(true)}
+        onCompositionEnd={() => setIsTyping(false)}
       />
 
       <div className="absolute bottom-0 p-2 w-fit flex flex-row justify-start">


### PR DESCRIPTION
Inputting Chinese, Japanese, or Korean text with a Latin keyboard necessitates the use of an Input Method Editor (IME). 

<img width="424" alt="image" src="https://github.com/user-attachments/assets/0c261e8c-7218-4bfa-9a00-8fcf8453d8ba" /> 

However, pressing Enter while the IME is active can interrupt the composition process and submit incomplete or incorrect text.  

To prevent this, the onCompositionStart and onCompositionEnd events can be leveraged to determine IME status and block submission until text composition is complete. 

ChatGPT utilizes this same approach.
