### PR TITLE
Fix incorrect model name in onUpdateDocument function

### DIFF
--- a/artifacts/code/server.ts
+++ b/artifacts/code/server.ts
@@ -42,7 +42,7 @@ export const codeDocumentHandler = createDocumentHandler<'code'>({
     let draftContent = '';
 
     const { fullStream } = streamObject({
-      model: myProvider.languageModel('artifacts-model'),
+      model: myProvider.languageModel('artifact-model'),
       system: updateDocumentPrompt(document.content, 'code'),
       prompt: description,
       schema: z.object({


### PR DESCRIPTION
This PR fixes a bug in the `onUpdateDocument` function where the model name was incorrectly set to 'artifacts-model' instead of 'artifact-model'. 

### Changes:
- Updated `myProvider.languageModel('artifacts-model')` to `myProvider.languageModel('artifact-model')`.

This change ensures the correct model is used, preventing errors in document updates.