### PR TITLE
chore: log the error

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -120,7 +120,8 @@ export async function POST(request: Request) {
         sendReasoning: true,
       });
     },
-    onError: () => {
+    onError: (error) => {
+      console.error(error);
       return 'Oops, an error occured!';
     },
   });


### PR DESCRIPTION
Here, we should explicitly print out the error message, as the `error` contains a wealth of useful debugging information.

