### PR TITLE
fix: check chat/vote ownership during actions

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -58,7 +58,12 @@ export async function POST(request: Request) {
       const title = await generateTitleFromUserMessage({
         message: userMessage,
       });
+
       await saveChat({ id, userId: session.user.id, title });
+    } else {
+      if (chat.userId !== session.user.id) {
+        return new Response('Unauthorized', { status: 401 });
+      }
     }
 
     await saveMessages({

--- a/app/(chat)/api/document/route.ts
+++ b/app/(chat)/api/document/route.ts
@@ -67,6 +67,7 @@ export async function POST(request: Request) {
 
     return Response.json(document, { status: 200 });
   }
+
   return new Response('Unauthorized', { status: 401 });
 }
 

--- a/app/(chat)/api/vote/route.ts
+++ b/app/(chat)/api/vote/route.ts
@@ -1,5 +1,5 @@
 import { auth } from '@/app/(auth)/auth';
-import { getVotesByChatId, voteMessage } from '@/lib/db/queries';
+import { getChatById, getVotesByChatId, voteMessage } from '@/lib/db/queries';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -12,6 +12,16 @@ export async function GET(request: Request) {
   const session = await auth();
 
   if (!session || !session.user || !session.user.email) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const chat = await getChatById({ id: chatId });
+
+  if (!chat) {
+    return new Response('Chat not found', { status: 404 });
+  }
+
+  if (chat.userId !== session.user.id) {
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -35,6 +45,16 @@ export async function PATCH(request: Request) {
   const session = await auth();
 
   if (!session || !session.user || !session.user.email) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const chat = await getChatById({ id: chatId });
+
+  if (!chat) {
+    return new Response('Chat not found', { status: 404 });
+  }
+
+  if (chat.userId !== session.user.id) {
     return new Response('Unauthorized', { status: 401 });
   }
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -57,6 +57,10 @@ export function Chat({
   const { data: votes } = useSWR<Array<Vote>>(
     `/api/vote?chatId=${id}`,
     fetcher,
+    {
+      refreshInterval: 0,
+      revalidateOnFocus: false,
+    },
   );
 
   const [attachments, setAttachments] = useState<Array<Attachment>>([]);

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -57,10 +57,6 @@ export function Chat({
   const { data: votes } = useSWR<Array<Vote>>(
     `/api/vote?chatId=${id}`,
     fetcher,
-    {
-      refreshInterval: 0,
-      revalidateOnFocus: false,
-    },
   );
 
   const [attachments, setAttachments] = useState<Array<Attachment>>([]);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
This pull request adds an explicit auth check for both `/chat` and `/vote` routes.