### PR TITLE
Fix (again): send message on Enter keypress only when not in input method mode

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -246,7 +246,11 @@ function PureMultimodalInput({
         rows={2}
         autoFocus
         onKeyDown={(event) => {
-          if (event.key === 'Enter' && !event.shiftKey) {
+          if (
+            event.key === "Enter" &&
+            !event.shiftKey &&
+            !event.nativeEvent.isComposing
+          ) {
             event.preventDefault();
 
             if (isLoading) {


### PR DESCRIPTION
This was implemented before, but regressed: https://github.com/vercel/ai-chatbot/pull/63 

Without this, typing in CJK language is difficult: https://github.com/vercel/ai-chatbot/issues/48