### PR TITLE
fix(auth): correct URL pathname checks to prevent redirect loop

### DIFF
--- a/app/(auth)/auth.config.ts
+++ b/app/(auth)/auth.config.ts
@@ -12,9 +12,10 @@ export const authConfig = {
   callbacks: {
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
-      const isOnChat = nextUrl.pathname.startsWith('/');
-      const isOnRegister = nextUrl.pathname.startsWith('/register');
-      const isOnLogin = nextUrl.pathname.startsWith('/login');
+      const { pathname } = nextUrl;
+      const isOnChat = pathname === '/';
+      const isOnRegister = pathname === '/register';
+      const isOnLogin = pathname === '/login';
 
       if (isLoggedIn && (isOnLogin || isOnRegister)) {
         return Response.redirect(new URL('/', nextUrl as unknown as URL));


### PR DESCRIPTION
Overview

This PR addresses an issue where users signing in via other providers would be redirected back to the login page in a loop. The root cause was an overly strict URL comparison within the authorized callback, which caused unexpected redirects for valid users. The comparison was checking startswith "/" which would match all 3 cases. I doubt this was the expected behavior.

Changes
	•	Updated the authorized callback in the NextAuth configuration to correctly compare nextUrl.pathname without creating new URL objects.
	•	Ensured that login and register paths are always accessible, and authenticated users are only redirected to / when appropriate.
	•	Aligned the isOnChat check to only target the homepage ("/"), preventing accidental mismatches with query parameters or sub-paths.

Impact
	•	Fixes the redirect loop on successful sign-in via alternate providers.
	•	Allows new and existing users to navigate between /login and /register as intended.
	•	Ensures that authenticated users remain at the root route and are only redirected when necessary.

Testing
	1.	Sign In: Using an alternate provider, verify that you are not redirected back to the login page after successful authentication.
	2.	Register: Confirm you can access and complete the registration flow without being redirected away prematurely.
	3.	Authenticated Navigation: Once signed in, ensure navigating to /login or /register correctly redirects you back to /.
	4.	Unauthenticated Access: Attempt accessing routes beyond /login or /register to confirm you are redirected to /login if not authenticated.

These changes should resolve the continuous redirect loop while still safeguarding private pages.