### PR TITLE
fix: poll votes after min message count

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -55,7 +55,7 @@ export function Chat({
   });
 
   const { data: votes } = useSWR<Array<Vote>>(
-    `/api/vote?chatId=${id}`,
+    messages.length >= 2 ? `/api/vote?chatId=${id}` : null,
     fetcher,
   );
 


### PR DESCRIPTION
This pull request only begins polling votes after reaching a minimum messages count (2) in a chat conversation.