### PR TITLE
Fix Stop Button Display Condition

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -253,7 +253,7 @@ function PureMultimodalInput({
       </div>
 
       <div className="absolute bottom-0 right-0 p-2 w-fit flex flex-row justify-end">
-        {status === 'submitted' ? (
+        {status === 'streaming' ? (
           <StopButton stop={stop} setMessages={setMessages} />
         ) : (
           <SendButton


### PR DESCRIPTION
This PR fixes an issue with the Stop button display in the multimodal input component. The condition was checking for `status === 'submitted'`, but it should be checking for `status === 'streaming'` instead.

According to the AI SDK documentation, the 'streaming' status indicates that the response is actively streaming in from the API, which is when the stop button should be displayed. 

This change ensures the stop button appears at the appropriate time during the chat interaction.