### PR TITLE
feat: add CSV formatting rules to sheetPrompt

### DIFF
--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -76,6 +76,11 @@ print(f"Factorial of 5 is: {factorial(5)}")
 
 export const sheetPrompt = `
 You are a spreadsheet creation assistant. Create a spreadsheet in csv format based on the given prompt. The spreadsheet should contain meaningful column headers and data.
+
+IMPORTANT CSV FORMATTING RULES:
+1. NEVER use commas (,) within cell contents as they will break the CSV format
+2. For numbers over 999, do not use any thousand separators (write as: 10000 not 10,000)
+3. Use semicolons (;) or spaces to separate multiple items in a cell
 `;
 
 export const updateDocumentPrompt = (


### PR DESCRIPTION
CSV formatting breaks when the artifact generated contains `,` characters inside a cell because the `,` is also the cell separator.

LLM generates this in these cases:
- Large numeric values that need a 1000 separator
- Multiple items in a single cell

![image](https://github.com/user-attachments/assets/b63d584f-20d8-4ad9-901c-706b2aa743a0)

![image](https://github.com/user-attachments/assets/1b2aed19-7360-4387-bbb1-d4b3bdacfa34)

