### PR TITLE
Optimize SendButton memo comparison for fewer re-renders

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -354,6 +354,7 @@ function PureSendButton({
 const SendButton = memo(PureSendButton, (prevProps, nextProps) => {
   if (prevProps.uploadQueue.length !== nextProps.uploadQueue.length)
     return false;
-  if (prevProps.input !== nextProps.input) return false;
+  if ((prevProps.input.length === 0) !== (nextProps.input.length === 0))
+    return false;
   return true;
 });


### PR DESCRIPTION
# Optimization for SendButton re-rendering

## What changed
Optimized the React.memo comparison function for SendButton to only trigger re-renders when the disabled state would actually change.

The comparison now explicitly checks for transitions between empty/non-empty states rather than re-rendering on every input change:

- Input transitions from empty to non-empty (or vice versa)

## Why this matters
This change significantly reduces unnecessary re-renders when typing in the input field. Previously, any character added or removed would trigger a re-render of the SendButton component, even though its visual state only changes when transitioning between empty and non-empty states.

## Performance impact
In large chat applications with frequent typing, this optimization helps reduce rendering overhead and improves responsiveness, particularly on lower-end devices.

## Testing
Verified that the button properly updates its disabled state when:
- Input field transitions between empty and non-empty
- Upload queue changes state