### PR TITLE
refactor(schema): move user table to schema-auth.ts for modularity

### DIFF
--- a/lib/db/schema-auth.ts
+++ b/lib/db/schema-auth.ts
@@ -1,0 +1,10 @@
+import type { InferSelectModel } from 'drizzle-orm';
+import { pgTable, varchar, uuid } from 'drizzle-orm/pg-core';
+
+export const user = pgTable('User', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  email: varchar('email', { length: 64 }).notNull(),
+  password: varchar('password', { length: 64 }),
+});
+
+export type User = InferSelectModel<typeof user>;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -10,14 +10,10 @@ import {
   foreignKey,
   boolean,
 } from 'drizzle-orm/pg-core';
+import { user } from './schema-auth';
 
-export const user = pgTable('User', {
-  id: uuid('id').primaryKey().notNull().defaultRandom(),
-  email: varchar('email', { length: 64 }).notNull(),
-  password: varchar('password', { length: 64 }),
-});
-
-export type User = InferSelectModel<typeof user>;
+export { user } from './schema-auth';
+export type { User } from './schema-auth';
 
 export const chat = pgTable('Chat', {
   id: uuid('id').primaryKey().notNull().defaultRandom(),


### PR DESCRIPTION
Isolated the User table definition into a separate file to improve maintainability and support custom auth without altering the main schema.ts

Currently is hard to keep core functionality changes in sync with main repo if you have any type of custom authentication or user attributes. Splitting them would help alleviate. 