### PR TITLE
refactor: replace patch with delete for /api/document

### DIFF
--- a/app/(chat)/api/document/route.ts
+++ b/app/(chat)/api/document/route.ts
@@ -77,19 +77,22 @@ export async function POST(request: Request) {
   return Response.json(document, { status: 200 });
 }
 
-export async function PATCH(request: Request) {
+export async function DELETE(request: Request) {
   const { searchParams } = new URL(request.url);
   const id = searchParams.get('id');
-
-  const { timestamp }: { timestamp: string } = await request.json();
+  const timestamp = searchParams.get('timestamp');
 
   if (!id) {
     return new Response('Missing id', { status: 400 });
   }
 
+  if (!timestamp) {
+    return new Response('Missing timestamp', { status: 400 });
+  }
+
   const session = await auth();
 
-  if (!session || !session.user) {
+  if (!session?.user?.id) {
     return new Response('Unauthorized', { status: 401 });
   }
 

--- a/components/version-footer.tsx
+++ b/components/version-footer.tsx
@@ -57,15 +57,15 @@ export const VersionFooter = ({
 
             mutate(
               `/api/document?id=${artifact.documentId}`,
-              await fetch(`/api/document?id=${artifact.documentId}`, {
-                method: 'PATCH',
-                body: JSON.stringify({
-                  timestamp: getDocumentTimestampByIndex(
-                    documents,
-                    currentVersionIndex,
-                  ),
-                }),
-              }),
+              await fetch(
+                `/api/document?id=${artifact.documentId}&timestamp=${getDocumentTimestampByIndex(
+                  documents,
+                  currentVersionIndex,
+                )}`,
+                {
+                  method: 'DELETE',
+                },
+              ),
               {
                 optimisticData: documents
                   ? [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-chatbot",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",


### PR DESCRIPTION
This pull request replaces `PATCH` method with `DELETE` method when deleting document versions through the `api/document` endpoint