### PR TITLE
chore: organize tests and tweak stream delays

### DIFF
--- a/lib/ai/models.test.ts
+++ b/lib/ai/models.test.ts
@@ -11,8 +11,8 @@ export const chatModel = new MockLanguageModelV1({
   }),
   doStream: async ({ prompt }) => ({
     stream: simulateReadableStream({
-      chunkDelayInMs: 50,
-      initialDelayInMs: 100,
+      chunkDelayInMs: 500,
+      initialDelayInMs: 1000,
       chunks: getResponseChunksByPrompt(prompt),
     }),
     rawCall: { rawPrompt: null, rawSettings: {} },
@@ -28,8 +28,8 @@ export const reasoningModel = new MockLanguageModelV1({
   }),
   doStream: async ({ prompt }) => ({
     stream: simulateReadableStream({
-      chunkDelayInMs: 50,
-      initialDelayInMs: 500,
+      chunkDelayInMs: 500,
+      initialDelayInMs: 1000,
       chunks: getResponseChunksByPrompt(prompt, true),
     }),
     rawCall: { rawPrompt: null, rawSettings: {} },
@@ -45,8 +45,8 @@ export const titleModel = new MockLanguageModelV1({
   }),
   doStream: async () => ({
     stream: simulateReadableStream({
-      chunkDelayInMs: 50,
-      initialDelayInMs: 100,
+      chunkDelayInMs: 500,
+      initialDelayInMs: 1000,
       chunks: [
         { type: 'text-delta', textDelta: 'This is a test title' },
         {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,11 +53,11 @@ export default defineConfig({
   projects: [
     {
       name: 'setup:auth',
-      testMatch: /auth.setup.ts/,
+      testMatch: /e2e\/auth.setup.ts/,
     },
     {
       name: 'setup:reasoning',
-      testMatch: /reasoning.setup.ts/,
+      testMatch: /e2e\/reasoning.setup.ts/,
       dependencies: ['setup:auth'],
       use: {
         ...devices['Desktop Chrome'],
@@ -66,7 +66,7 @@ export default defineConfig({
     },
     {
       name: 'chat',
-      testMatch: /chat.test.ts/,
+      testMatch: /e2e\/chat.test.ts/,
       dependencies: ['setup:auth'],
       use: {
         ...devices['Desktop Chrome'],
@@ -75,7 +75,7 @@ export default defineConfig({
     },
     {
       name: 'reasoning',
-      testMatch: /reasoning.test.ts/,
+      testMatch: /e2e\/reasoning.test.ts/,
       dependencies: ['setup:reasoning'],
       use: {
         ...devices['Desktop Chrome'],
@@ -84,7 +84,7 @@ export default defineConfig({
     },
     {
       name: 'artifacts',
-      testMatch: /artifacts.test.ts/,
+      testMatch: /e2e\/artifacts.test.ts/,
       dependencies: ['setup:auth'],
       use: {
         ...devices['Desktop Chrome'],

--- a/tests/e2e/artifacts.test.ts
+++ b/tests/e2e/artifacts.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { ChatPage } from './pages/chat';
-import { ArtifactPage } from './pages/artifact';
+import { ChatPage } from '../pages/chat';
+import { ArtifactPage } from '../pages/artifact';
 
 test.describe('artifacts activity', () => {
   let chatPage: ChatPage;

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,9 +1,9 @@
-import path from 'path';
+import path from 'node:path';
 import { generateId } from 'ai';
 import { getUnixTime } from 'date-fns';
 import { expect, test as setup } from '@playwright/test';
 
-const authFile = path.join(__dirname, '../playwright/.auth/session.json');
+const authFile = path.join(__dirname, '../../playwright/.auth/session.json');
 
 setup('authenticate', async ({ page }) => {
   const testEmail = `test-${getUnixTime(new Date())}@playwright.com`;

--- a/tests/e2e/auth.test.ts
+++ b/tests/e2e/auth.test.ts
@@ -1,6 +1,6 @@
 import { generateId } from 'ai';
 import { getUnixTime } from 'date-fns';
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 test.use({ storageState: { cookies: [], origins: [] } });
 

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -1,4 +1,4 @@
-import { ChatPage } from './pages/chat';
+import { ChatPage } from '../pages/chat';
 import { test, expect } from '@playwright/test';
 
 test.describe('chat activity', () => {

--- a/tests/e2e/reasoning.setup.ts
+++ b/tests/e2e/reasoning.setup.ts
@@ -1,10 +1,10 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test as setup } from '@playwright/test';
-import { ChatPage } from './pages/chat';
+import { ChatPage } from '../pages/chat';
 
 const reasoningFile = path.join(
   __dirname,
-  '../playwright/.reasoning/session.json',
+  '../../playwright/.reasoning/session.json',
 );
 
 setup('switch to reasoning model', async ({ page }) => {

--- a/tests/e2e/reasoning.test.ts
+++ b/tests/e2e/reasoning.test.ts
@@ -1,4 +1,4 @@
-import { ChatPage } from './pages/chat';
+import { ChatPage } from '../pages/chat';
 import { test, expect } from '@playwright/test';
 
 test.describe('chat activity with reasoning', () => {


### PR DESCRIPTION
This pull requests does the following:
- [x] Increase chunk delays and time to first token when simulating streams
- [x] Move end to end tests to `e2e/` folder

Fixes #935 