### PR TITLE
Fix: Update document tool to generate a new id after update

### DIFF
--- a/lib/ai/tools/update-document.ts
+++ b/lib/ai/tools/update-document.ts
@@ -3,6 +3,7 @@ import { Session } from 'next-auth';
 import { z } from 'zod';
 import { getDocumentById, saveDocument } from '@/lib/db/queries';
 import { documentHandlersByArtifactKind } from '@/lib/artifacts/server';
+import { generateUUID } from '@/lib/utils';
 
 interface UpdateDocumentProps {
   session: Session;
@@ -41,6 +42,9 @@ export const updateDocument = ({ session, dataStream }: UpdateDocumentProps) =>
         throw new Error(`No document handler found for kind: ${document.kind}`);
       }
 
+      const documentId = generateUUID();
+      document.id = documentId;
+
       await documentHandler.onUpdateDocument({
         document,
         description,
@@ -51,7 +55,7 @@ export const updateDocument = ({ session, dataStream }: UpdateDocumentProps) =>
       dataStream.writeData({ type: 'finish', content: '' });
 
       return {
-        id,
+        id: documentId,
         title: document.title,
         kind: document.kind,
         content: 'The document has been updated successfully.',


### PR DESCRIPTION
## Issue：  
This project's artifact will have an editing feature, but the newly edited results will overwrite historical artifacts. For example, when Python code V1 is output and I prompt a modification to produce V2, clicking on V1's code displays V2 instead. This differs from projects like v0.dev, which allow viewing rendered content of different artifact versions.  

Furthermore, I discovered that the primary key in the Document table of the database is not unique. In the earlier example, querying the database reveals two records with identical IDs—a result that is often confusing and meaningless.  

![image](https://github.com/user-attachments/assets/fbdb320f-dffa-4e0a-8499-889b96efa3ea)


## Solution:  
At the `onUpdate` stage, generate a new UUID and save it as a new version.