### PR TITLE
Add conditional scrolling to useScrollToBottom hook

### DIFF
--- a/components/use-scroll-to-bottom.ts
+++ b/components/use-scroll-to-bottom.ts
@@ -6,24 +6,39 @@ export function useScrollToBottom<T extends HTMLElement>(): [
 ] {
   const containerRef = useRef<T>(null);
   const endRef = useRef<T>(null);
+  const shouldScrollRef = useRef(true);
 
   useEffect(() => {
     const container = containerRef.current;
     const end = endRef.current;
 
     if (container && end) {
-      const observer = new MutationObserver(() => {
-        end.scrollIntoView({ behavior: 'instant', block: 'end' });
+      const intersectionObserver = new IntersectionObserver(
+        ([entry]) => {
+          shouldScrollRef.current = entry.isIntersecting;
+        },
+        { threshold: 0 },
+      );
+
+      intersectionObserver.observe(end);
+
+      const mutationObserver = new MutationObserver(() => {
+        if (shouldScrollRef.current) {
+          end.scrollIntoView({ behavior: 'instant', block: 'end' });
+        }
       });
 
-      observer.observe(container, {
+      mutationObserver.observe(container, {
         childList: true,
         subtree: true,
         attributes: true,
         characterData: true,
       });
 
-      return () => observer.disconnect();
+      return () => {
+        intersectionObserver.disconnect();
+        mutationObserver.disconnect();
+      };
     }
   }, []);
 


### PR DESCRIPTION
### Description
This PR enhances the `useScrollToBottom` hook by introducing conditional scrolling behavior. It uses an `IntersectionObserver` to detect whether the bottom element is in the viewport. Automatic scrolling to the bottom only occurs when the user is near or at the bottom, preventing unwanted scrolling when viewing earlier content (e.g., in a chat or log view).

### Changes
- Added `shouldScrollRef` to track whether scrolling to the bottom is needed.
- Implemented `IntersectionObserver` to monitor the visibility of the bottom element (`endRef`).
- Updated scrolling logic to execute `scrollIntoView` only when the bottom element is visible.
- Added cleanup for `IntersectionObserver` in the `useEffect` return function.