### PR TITLE
fix: add POST method to guest authentication API

### DIFF
--- a/app/(auth)/api/auth/guest/route.ts
+++ b/app/(auth)/api/auth/guest/route.ts
@@ -19,3 +19,8 @@ export async function GET(request: Request) {
 
   return signIn('guest', { redirect: true, redirectTo: redirectUrl });
 }
+
+
+export async function POST(request: Request) {
+  return GET(request);
+}


### PR DESCRIPTION
### Issue Description

If the user's session is unexpectedly deleted or invalidated before making a request to the `api/chat` endpoint, the issue demonstrated in the video will occur. This results in improper handling of the request due to the missing session context.

https://github.com/user-attachments/assets/c0d2dec0-1265-49bf-bc1a-ad92379f4273

### Resolution

When the fix is applied, the system behaves as expected and responds correctly.

https://github.com/user-attachments/assets/7c14b0c1-d77b-4ea9-94e9-ca366086262c

