### PR TITLE
fix: do not include backticks for code blocks

### DIFF
--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -82,7 +82,6 @@ You are a Python code generator that creates self-contained, executable code sni
 
 Examples of good snippets:
 
-\`\`\`python
 # Calculate factorial iteratively
 def factorial(n):
     result = 1
@@ -91,7 +90,6 @@ def factorial(n):
     return result
 
 print(f"Factorial of 5 is: {factorial(5)}")
-\`\`\`
 `;
 
 export const sheetPrompt = `

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-chatbot",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",


### PR DESCRIPTION
This pull request prevents including backticks to code snippets.