### PR TITLE
fix: conditionally render attachments component

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -18,7 +18,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { MessageEditor } from './message-editor';
 import { DocumentPreview } from './document-preview';
 import { MessageReasoning } from './message-reasoning';
-import { UseChatHelpers } from '@ai-sdk/react';
+import type { UseChatHelpers } from '@ai-sdk/react';
 
 const PurePreviewMessage = ({
   chatId,
@@ -66,19 +66,20 @@ const PurePreviewMessage = ({
           )}
 
           <div className="flex flex-col gap-4 w-full">
-            {message.experimental_attachments && (
-              <div
-                data-testid={`message-attachments`}
-                className="flex flex-row justify-end gap-2"
-              >
-                {message.experimental_attachments.map((attachment) => (
-                  <PreviewAttachment
-                    key={attachment.url}
-                    attachment={attachment}
-                  />
-                ))}
-              </div>
-            )}
+            {message.experimental_attachments &&
+              message.experimental_attachments.length > 0 && (
+                <div
+                  data-testid={`message-attachments`}
+                  className="flex flex-row justify-end gap-2"
+                >
+                  {message.experimental_attachments.map((attachment) => (
+                    <PreviewAttachment
+                      key={attachment.url}
+                      attachment={attachment}
+                    />
+                  ))}
+                </div>
+              )}
 
             {message.parts?.map((part, index) => {
               const { type } = part;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-chatbot",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",


### PR DESCRIPTION
This pull request fixes an alignment issue that was cause by not rendering the attachments component even when there was none.

Before:
<img width="493" alt="Screenshot 2025-04-29 at 5 39 39 PM" src="https://github.com/user-attachments/assets/10482e86-7214-40ae-8f70-ca6eec23c0ec" />

After:
<img width="504" alt="Screenshot 2025-04-29 at 5 39 48 PM" src="https://github.com/user-attachments/assets/15868474-2afd-41ff-9beb-4142671a9aed" />