### PR TITLE
chore: tweak migration script to handle message order

### DIFF
--- a/lib/db/helpers/01-core-to-parts.ts
+++ b/lib/db/helpers/01-core-to-parts.ts
@@ -24,7 +24,7 @@ const client = postgres(process.env.POSTGRES_URL);
 const db = drizzle(client);
 
 const BATCH_SIZE = 100; // Process 100 chats at a time
-const INSERT_BATCH_SIZE = 100; // Insert 100 messages at a time
+const INSERT_BATCH_SIZE = 1000; // Insert 1000 messages at a time
 
 type NewMessageInsert = {
   id: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-chatbot",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",


### PR DESCRIPTION
This pull request fixes the following behaviors in the migration script:
- [x] use correct order of messages when their creation timestamps are the same
- [x] dedupe reasoning parts in a message