### PR TITLE
Update Vercel Blob and Postgres documentation URLs in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@ AUTH_SECRET=****
 # Get your xAI API Key here for chat and image models: https://console.x.ai/
 XAI_API_KEY=****
 
-# Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob
+# Instructions to create a Vercel Blob Store here: https://vercel.com/docs/vercel-blob
 BLOB_READ_WRITE_TOKEN=****
 
-# Instructions to create a PostgreSQL database here: https://vercel.com/docs/storage/vercel-postgres/quickstart
+# Instructions to create a PostgreSQL database here: https://vercel.com/docs/postgres
 POSTGRES_URL=****
 
 


### PR DESCRIPTION
The documentation URLs for Vercel Blob Store and PostgreSQL in .env.example were outdated and now redirect (HTTP 308) to new locations.

```
❯ curl -s -o /dev/null -w "status: %{http_code}\nlocation: %{redirect_url}\n" https://vercel.com/docs/storage/vercel-postgres/quickstart
status: 308
location: https://vercel.com/docs/postgres

❯ curl -s -o /dev/null -w "status: %{http_code}\nlocation: %{redirect_url}\n" https://vercel.com/docs/storage/vercel-blob
status: 308
location: https://vercel.com/docs/vercel-blob/
```