### PR TITLE
refactor: simplify chat model selection logic in chat page

### DIFF
--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -52,31 +52,14 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
   }
 
   const cookieStore = await cookies();
-  const chatModelFromCookie = cookieStore.get('chat-model');
-
-  if (!chatModelFromCookie) {
-    return (
-      <>
-        <Chat
-          id={chat.id}
-          initialMessages={convertToUIMessages(messagesFromDb)}
-          initialChatModel={DEFAULT_CHAT_MODEL}
-          initialVisibilityType={chat.visibility}
-          isReadonly={session?.user?.id !== chat.userId}
-          session={session}
-          autoResume={true}
-        />
-        <DataStreamHandler id={id} />
-      </>
-    );
-  }
+  const chatModel = cookieStore.get('chat-model')?.value ?? DEFAULT_CHAT_MODEL;
 
   return (
     <>
       <Chat
         id={chat.id}
         initialMessages={convertToUIMessages(messagesFromDb)}
-        initialChatModel={chatModelFromCookie.value}
+        initialChatModel={chatModel}
         initialVisibilityType={chat.visibility}
         isReadonly={session?.user?.id !== chat.userId}
         session={session}

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -17,25 +17,7 @@ export default async function Page() {
   const id = generateUUID();
 
   const cookieStore = await cookies();
-  const modelIdFromCookie = cookieStore.get('chat-model');
-
-  if (!modelIdFromCookie) {
-    return (
-      <>
-        <Chat
-          key={id}
-          id={id}
-          initialMessages={[]}
-          initialChatModel={DEFAULT_CHAT_MODEL}
-          initialVisibilityType="private"
-          isReadonly={false}
-          session={session}
-          autoResume={false}
-        />
-        <DataStreamHandler id={id} />
-      </>
-    );
-  }
+  const chatModel = cookieStore.get('chat-model')?.value ?? DEFAULT_CHAT_MODEL;
 
   return (
     <>
@@ -43,7 +25,7 @@ export default async function Page() {
         key={id}
         id={id}
         initialMessages={[]}
-        initialChatModel={modelIdFromCookie.value}
+        initialChatModel={chatModel}
         initialVisibilityType="private"
         isReadonly={false}
         session={session}


### PR DESCRIPTION
## Description of change:
This refactor simplifies the `app/(chat)/[id]/page.tsx` and `app/(chat)/page.tsx` component logic by reducing the redundancy in JSX. 

Instead of repeating the JSX code within conditional blocks, I introduced a single variable `chatModel`.

This variable determines the value of `initialChatModel` by falling back to a default model `DEFAULT_CHAT_MODEL` if no model is found in the cookies.
 