### PR TITLE
fix: prevent Enter key from submitting during file upload

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -282,6 +282,12 @@ function PureMultimodalInput({
           ) {
             event.preventDefault();
 
+            // Prevent submitting if a file is uploading
+            if (uploadQueue.length > 0) {
+              toast.error('Please wait for the file upload to finish!');
+              return;
+            }
+
             if (status !== 'ready') {
               toast.error('Please wait for the model to finish its response!');
             } else {


### PR DESCRIPTION
This PR fixes an issue where pressing Enter would unintentionally submit a message even if a file was still uploading. 

Now, the Enter key is disabled while files are uploading in the multimodal input component, matching the behavior of the disabled Send button

Changes:
- Added a check in the onKeyDown handler to prevent submission if uploadQueue.length > 0.
- Shows a toast error if attempted.
- This improves UX and prevents incomplete messages from being sent while uploads are in progress.