### PR TITLE
Enhance attachment preview

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -237,6 +237,9 @@ export async function POST(request: Request) {
     if (error instanceof ChatSDKError) {
       return error.toResponse();
     }
+
+    console.error(error);
+    return new Response('Internal Server Error', { status: 500 });
   }
 }
 

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -244,8 +244,16 @@ function PureMultimodalInput({
           data-testid="attachments-preview"
           className="flex flex-row gap-2 overflow-x-scroll items-end"
         >
-          {attachments.map((attachment) => (
-            <PreviewAttachment key={attachment.url} attachment={attachment} />
+          {attachments.map((attachment, idx) => (
+            <PreviewAttachment 
+              key={attachment.url} 
+              attachment={attachment} 
+              onRemove={() => {
+                setAttachments((prev) =>
+                  prev.filter((_, i) => i !== idx)
+                );
+              }}
+            />
           ))}
 
           {uploadQueue.map((filename) => (

--- a/components/preview-attachment.tsx
+++ b/components/preview-attachment.tsx
@@ -32,7 +32,7 @@ export const PreviewAttachment = ({
                 key={url}
                 src={url}
                 alt={name ?? "An image attachment"}
-                className="rounded-md size-full object-cover"
+                className="rounded-md size-full object-cover cursor-pointer"
                 onClick={() => setShowPreview(true)}
               />
             ) : (
@@ -82,7 +82,7 @@ export const PreviewAttachment = ({
             >
               ×
             </button>
-            
+
             {/* NOTE: it is recommended to use next/image for images */}
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img

--- a/components/preview-attachment.tsx
+++ b/components/preview-attachment.tsx
@@ -1,6 +1,9 @@
-import type { Attachment } from 'ai';
+"use client";
 
-import { LoaderIcon } from './icons';
+import type { Attachment } from "ai";
+
+import { LoaderIcon } from "./icons";
+import { useState } from "react";
 
 export const PreviewAttachment = ({
   attachment,
@@ -12,48 +15,85 @@ export const PreviewAttachment = ({
   onRemove?: () => void;
 }) => {
   const { name, url, contentType } = attachment;
+  const [showPreview, setShowPreview] = useState(false);
 
   return (
-    <div data-testid="input-attachment-preview" className="flex flex-col gap-2">
-      <div className="w-20 h-16 aspect-video bg-muted rounded-md relative flex flex-col items-center justify-center">
-        {contentType ? (
-          contentType.startsWith('image') ? (
-            // NOTE: it is recommended to use next/image for images
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              key={url}
-              src={url}
-              alt={name ?? 'An image attachment'}
-              className="rounded-md size-full object-cover"
-            />
+    <>
+      <div
+        data-testid="input-attachment-preview"
+        className="flex flex-col gap-2"
+      >
+        <div className="w-20 h-16 aspect-video bg-muted rounded-md relative flex flex-col items-center justify-center">
+          {contentType ? (
+            contentType.startsWith("image") ? (
+              // NOTE: it is recommended to use next/image for images
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                key={url}
+                src={url}
+                alt={name ?? "An image attachment"}
+                className="rounded-md size-full object-cover"
+                onClick={() => setShowPreview(true)}
+              />
+            ) : (
+              <div className="" />
+            )
           ) : (
             <div className="" />
-          )
-        ) : (
-          <div className="" />
-        )}
+          )}
 
-        {onRemove && (
-          <button
-            type="button"
-            onClick={onRemove}
-            className="absolute top-1 right-1 size-5 rounded-full bg-zinc-100 text-black hover:bg-zinc-700 hover:text-white flex items-center justify-center shadow text-xs transition border border-zinc-700"
-            style={{ zIndex: 10 }}
-          >
-            ×
-          </button>
-        )}
+          {onRemove && (
+            <button
+              type="button"
+              onClick={onRemove}
+              className="absolute top-1 right-1 size-5 rounded-full bg-zinc-100 text-black hover:bg-zinc-700 hover:text-white flex items-center justify-center shadow text-xs transition border border-zinc-700"
+              style={{ zIndex: 10 }}
+            >
+              ×
+            </button>
+          )}
 
-        {isUploading && (
-          <div
-            data-testid="input-attachment-loader"
-            className="animate-spin absolute text-zinc-500"
-          >
-            <LoaderIcon />
-          </div>
-        )}
+          {isUploading && (
+            <div
+              data-testid="input-attachment-loader"
+              className="animate-spin absolute text-zinc-500"
+            >
+              <LoaderIcon />
+            </div>
+          )}
+        </div>
+        <div className="text-xs text-zinc-500 max-w-16 truncate">{name}</div>
       </div>
-      <div className="text-xs text-zinc-500 max-w-16 truncate">{name}</div>
-    </div>
+
+      {showPreview && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+          onClick={() => setShowPreview(false)}
+        >
+          <div className="relative">
+            <button
+              type="button"
+              className="absolute top-1 right-1 size-8 rounded-full bg-zinc-100 text-black hover:bg-zinc-700 hover:text-white flex items-center justify-center shadow text-xl transition border border-zinc-700"
+              style={{ zIndex: 60 }}
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowPreview(false);
+              }}
+            >
+              ×
+            </button>
+            
+            {/* NOTE: it is recommended to use next/image for images */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={url}
+              alt={name ?? "An image attachment"}
+              className="max-w-[90vw] max-h-[90vh] rounded-lg shadow-lg"
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>
+        </div>
+      )}
+    </>
   );
 };

--- a/components/preview-attachment.tsx
+++ b/components/preview-attachment.tsx
@@ -5,9 +5,11 @@ import { LoaderIcon } from './icons';
 export const PreviewAttachment = ({
   attachment,
   isUploading = false,
+  onRemove,
 }: {
   attachment: Attachment;
   isUploading?: boolean;
+  onRemove?: () => void;
 }) => {
   const { name, url, contentType } = attachment;
 
@@ -29,6 +31,17 @@ export const PreviewAttachment = ({
           )
         ) : (
           <div className="" />
+        )}
+
+        {onRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="absolute top-1 right-1 size-5 rounded-full bg-zinc-100 text-black hover:bg-zinc-700 hover:text-white flex items-center justify-center shadow text-xs transition border border-zinc-700"
+            style={{ zIndex: 10 }}
+          >
+            ×
+          </button>
         )}
 
         {isUploading && (


### PR DESCRIPTION
### Features:
- Attachment Preview Enlargement:
  Clicking on an image attachment now displays a larger preview, inspired by the ChatGPT user experience.
- Attachment Deletion:
   Users can now delete selected attachments before sending a message.

See the demonstration below:

https://github.com/user-attachments/assets/233b4825-dd08-44a6-becb-76efc8025899

---
The deletion feature is related to #924 and #774. 
