### PR TITLE
Remove maximum message length of 2000 characters (500 tokens)

### DIFF
--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const textPartSchema = z.object({
-  text: z.string().min(1).max(2000),
+  text: z.string().min(1),
   type: z.enum(['text']),
 });
 
@@ -11,13 +11,13 @@ export const postRequestBodySchema = z.object({
     id: z.string().uuid(),
     createdAt: z.coerce.date(),
     role: z.enum(['user']),
-    content: z.string().min(1).max(2000),
+    content: z.string().min(1),
     parts: z.array(textPartSchema),
     experimental_attachments: z
       .array(
         z.object({
           url: z.string().url(),
-          name: z.string().min(1).max(2000),
+          name: z.string().min(1),
           contentType: z.enum(['image/png', 'image/jpg', 'image/jpeg']),
         }),
       )


### PR DESCRIPTION
In the zod schema, we have a hardcoded max length on strings! This took me a bit of work debugging, and it seems very arbitrary, so here's a PR removing it.

It would say "The request couldn't be processed. Please check your input and try again." in this popup, and show no other useful information:

<img width="381" alt="Screenshot 2025-05-27 at 09 59 32" src="https://github.com/user-attachments/assets/54733e9a-b889-45de-8c3b-7a78960675b1" />