### PR TITLE
fix: Preserve newlines in messages

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -125,7 +125,7 @@ const PurePreviewMessage = ({
 
                       <div
                         data-testid="message-content"
-                        className={cn('flex flex-col gap-4', {
+                        className={cn('flex flex-col gap-4 whitespace-pre-wrap', {
                           'bg-primary text-primary-foreground px-3 py-2 rounded-xl':
                             message.role === 'user',
                         })}


### PR DESCRIPTION
This ensures that newline characters are preserved when rendering messages