### PR TITLE
Fix off by one in getDocumentTimestampByIndex

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -69,7 +69,7 @@ export function getDocumentTimestampByIndex(
   index: number,
 ) {
   if (!documents) return new Date();
-  if (index > documents.length) return new Date();
+  if (index >= documents.length) return new Date();
 
   return documents[index].createdAt;
 }


### PR DESCRIPTION
The current check is
```
if (index > documents.length) return new Date();
...
return documents[index].createdAt;
```

This will crash with `undefined.createdAt` whenever `index === documents.length`