### PR TITLE
fix(artifact): correct messages comparison in component's memo condition

### DIFF
--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -506,7 +506,7 @@ export const Artifact = memo(PureArtifact, (prevProps, nextProps) => {
   if (prevProps.status !== nextProps.status) return false;
   if (!equal(prevProps.votes, nextProps.votes)) return false;
   if (prevProps.input !== nextProps.input) return false;
-  if (!equal(prevProps.messages, nextProps.messages.length)) return false;
+  if (!equal(prevProps.messages, nextProps.messages)) return false;
   if (prevProps.selectedVisibilityType !== nextProps.selectedVisibilityType)
     return false;
 


### PR DESCRIPTION
## Description

The `Artifact` component's memo condition compared the previous `messages` to the next `messages`'s length. This results in the memo comparison being always false and the memo doing nothing (the component will always re-render)