### PR TITLE
fix: ensure useEffect triggers on repeated same-status submissions

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -42,7 +42,7 @@ export default function Page() {
       updateSession();
       router.refresh();
     }
-  }, [state.status]);
+  }, [state]);
 
   const handleSubmit = (formData: FormData) => {
     setEmail(formData.get('email') as string);


### PR DESCRIPTION
Previously, useEffect was only dependent on `state.status`, which caused a bug where repeated form submissions with the same status (e.g., "failed") would not trigger the effect again, preventing toast messages from reappearing.

This fix changes the dependency array to use the full `state` object.