### PR TITLE
Render MessageReasoning only if text is present

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -103,7 +103,7 @@ const PurePreviewMessage = ({
               const { type } = part;
               const key = `message-${message.id}-part-${index}`;
 
-              if (type === 'reasoning') {
+              if (type === 'reasoning' && part.text) {
                 return (
                   <MessageReasoning
                     key={key}


### PR DESCRIPTION
Updated the condition to render the MessageReasoning component only when the part type is 'reasoning' and part.text exists. This prevents rendering empty reasoning components.