### PR TITLE
fix(artifacts): Update text stream type to 'text-delta'

### DIFF
--- a/artifacts/text/server.ts
+++ b/artifacts/text/server.ts
@@ -19,7 +19,7 @@ export const textDocumentHandler = createDocumentHandler<'text'>({
     for await (const delta of fullStream) {
       const { type } = delta;
 
-      if (type === 'text') {
+      if (type === 'text-delta') {
         const { text } = delta;
 
         draftContent += text;
@@ -55,7 +55,7 @@ export const textDocumentHandler = createDocumentHandler<'text'>({
     for await (const delta of fullStream) {
       const { type } = delta;
 
-      if (type === 'text') {
+      if (type === 'text-delta') {
         const { text } = delta;
 
         draftContent += text;


### PR DESCRIPTION
This PR fixes a type error in artifacts/text/server.ts that now occurs since the recent updates in the SDK post-beta versions.

The `ai` package now emits text stream parts with the type 'text-delta', while the code was still checking for the older 'text' type.

Fixes #1109