### PR TITLE
Fix attachment filename

### DIFF
--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -8,7 +8,7 @@ const textPartSchema = z.object({
 const filePartSchema = z.object({
   type: z.enum(['file']),
   mediaType: z.enum(['image/jpeg', 'image/png']),
-  name: z.string().min(1).max(100),
+  filename: z.string().min(1).max(100),
   url: z.string().url(),
 });
 

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -117,7 +117,7 @@ function PureMultimodalInput({
         ...attachments.map((attachment) => ({
           type: 'file' as const,
           url: attachment.url,
-          name: attachment.name,
+          filename: attachment.name,
           mediaType: attachment.contentType,
         })),
         {


### PR DESCRIPTION
Currently, the chat UI cannot read attachment filenames correctly, and the filenames always fall back to `file`. This PR fixes it. 