### PR TITLE
fix: artifact persistence across chat navigation

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -11,7 +11,11 @@ import { Artifact } from './artifact';
 import { MultimodalInput } from './multimodal-input';
 import { Messages } from './messages';
 import type { VisibilityType } from './visibility-selector';
-import { useArtifactSelector } from '@/hooks/use-artifact';
+import {
+  useArtifactSelector,
+  useArtifact,
+  initialArtifactData,
+} from '@/hooks/use-artifact';
 import { unstable_serialize } from 'swr/infinite';
 import { getChatHistoryPaginationKey } from './sidebar-history';
 import { toast } from './toast';
@@ -118,6 +122,11 @@ export function Chat({
 
   const [attachments, setAttachments] = useState<Array<Attachment>>([]);
   const isArtifactVisible = useArtifactSelector((state) => state.isVisible);
+  const { setArtifact } = useArtifact();
+
+  useEffect(() => {
+    setArtifact({ ...initialArtifactData, status: 'idle' });
+  }, [id, setArtifact]);
 
   useAutoResume({
     autoResume,


### PR DESCRIPTION
Artifacts were persisting in global SWR cache and reopening when navigating between chats.

This fix resets artifact state when Chat component mounts, ensuring each chat starts clean.

Fixes the issue where closed artifacts from one chat would reopen in other chats.

Tested: artifact generation, closing, and navigation between chats works correctly.