### PR TITLE
docs: add database migration step to local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You will need to use the environment variables [defined in `.env.example`](.env.
 
 ```bash
 pnpm install
+pnpm db:migrate # Setup database or apply latest database changes
 pnpm dev
 ```
 


### PR DESCRIPTION
Add `pnpm db:migrate` to the running locally section to ensure database tables are created for first-time setup and applied when pulling latest schema changes.