### PR TITLE
fix(auth): resolve infinite loop in login and register pages

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -42,7 +42,7 @@ export default function Page() {
       updateSession();
       router.refresh();
     }
-  }, [state.status, router, updateSession]);
+  }, [state.status]);
 
   const handleSubmit = (formData: FormData) => {
     setEmail(formData.get('email') as string);

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -43,7 +43,7 @@ export default function Page() {
       updateSession();
       router.refresh();
     }
-  }, [state, router, updateSession]);
+  }, [state.status]);
 
   const handleSubmit = (formData: FormData) => {
     setEmail(formData.get('email') as string);


### PR DESCRIPTION
Remove router and updateSession from useEffect dependencies to prevent
infinite re-renders. Only state.status is needed as a dependency since
it's the only value that should trigger the effect to run.