### PR TITLE
Add `vercel-template.json`

### DIFF
--- a/vercel-template.json
+++ b/vercel-template.json
@@ -1,0 +1,19 @@
+{
+  "products": [
+    {
+      "type": "integration",
+      "protocol": "storage",
+      "productSlug": "neon",
+      "integrationSlug": "neon"
+    },
+    {
+      "type": "integration",
+      "protocol": "storage",
+      "productSlug": "upstash-kv",
+      "integrationSlug": "upstash"
+    },
+    {
+      "type": "blob"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds `vercel-template.json` for specifying configuration at `vercel.com/templates`

## Why are we doing this?

We'd like to move more template configuration into GitHub as the "source of truth"