### PR TITLE
[docs] Update deploy URLs to point to `/templates/next.js/nextjs-ai-chatbot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ With the [AI SDK](https://ai-sdk.dev/docs/introduction), you can also switch to 
 
 You can deploy your own version of the Next.js AI Chatbot to Vercel with one click:
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai-chatbot&env=AUTH_SECRET&envDescription=Generate%20a%20random%20secret%20to%20use%20for%20authentication&envLink=https%3A%2F%2Fgenerate-secret.vercel.app%2F32&project-name=my-awesome-chatbot&repository-name=my-awesome-chatbot&demo-title=AI%20Chatbot&demo-description=An%20Open-Source%20AI%20Chatbot%20Template%20Built%20With%20Next.js%20and%20the%20AI%20SDK%20by%20Vercel&demo-url=https%3A%2F%2Fchat.vercel.ai&products=%5B%7B%22type%22%3A%22integration%22%2C%22protocol%22%3A%22storage%22%2C%22productSlug%22%3A%22neon%22%2C%22integrationSlug%22%3A%22neon%22%7D%2C%7B%22type%22%3A%22blob%22%7D%5D)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/templates/next.js/nextjs-ai-chatbot)
 
 ## Running locally
 

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -59,8 +59,9 @@ function PureChatHeader({
         asChild
       >
         <Link
-          href={`https://vercel.com/new/clone?repository-url=https://github.com/vercel/ai-chatbot&env=AUTH_SECRET&envDescription=Learn more about how to get the API Keys for the application&envLink=https://github.com/vercel/ai-chatbot/blob/main/.env.example&demo-title=AI Chatbot&demo-description=An Open-Source AI Chatbot Template Built With Next.js and the AI SDK by Vercel.&demo-url=https://chat.vercel.ai&products=[{"type":"integration","protocol":"storage","productSlug":"neon","integrationSlug":"neon"},{"type":"integration","protocol":"storage","productSlug":"upstash-kv","integrationSlug":"upstash"},{"type":"blob"}]`}
+          href={`https://vercel.com/templates/next.js/nextjs-ai-chatbot`}
           target="_noblank"
+          rel="noreferrer"
         >
           <VercelIcon size={16} />
           Deploy with Vercel


### PR DESCRIPTION
### TLDR

Updated deployment URLs from legacy clone-based flow to use Vercel templates.

### Problem

In this repo, we reference Vercel deployment URLs directly, and these use the legacy clone-based deployment flow which make the update process tedious as these values have to be updated whenever the template requirements change. 

### Solution

Replace all instances of the clone flow invoke URL with the Vercel templates URL so it becomes the canonical source of truth. This is a stop-gap until we can switch away from using our CMS as the source of truth in favor of a file at the root of the repo that is used as a template.

Work has started on that here: #1193 

This PR updates all usages to ensure users are directed to the correct, maintained deployment flow. It also removes the need for updates to code when the template requirements change.