### PR TITLE
fix(chat): model selection persistence when switching between models

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -2,7 +2,7 @@
 
 import { DefaultChatTransport } from 'ai';
 import { useChat } from '@ai-sdk/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import { ChatHeader } from '@/components/chat-header';
 import type { Vote } from '@/lib/db/schema';
@@ -64,6 +64,12 @@ export function Chat({
   const [input, setInput] = useState<string>('');
   const [usage, setUsage] = useState<AppUsage | undefined>(initialLastContext);
   const [showCreditCardAlert, setShowCreditCardAlert] = useState(false);
+  const [currentModelId, setCurrentModelId] = useState(initialChatModel);
+  const currentModelIdRef = useRef(currentModelId);
+  
+  useEffect(() => {
+    currentModelIdRef.current = currentModelId;
+  }, [currentModelId]);
 
   const {
     messages,
@@ -86,7 +92,7 @@ export function Chat({
           body: {
             id,
             message: messages.at(-1),
-            selectedChatModel: initialChatModel,
+            selectedChatModel: currentModelIdRef.current,
             selectedVisibilityType: visibilityType,
             ...body,
           },
@@ -185,7 +191,8 @@ export function Chat({
               setMessages={setMessages}
               sendMessage={sendMessage}
               selectedVisibilityType={visibilityType}
-              selectedModelId={initialChatModel}
+              selectedModelId={currentModelId}
+              onModelChange={setCurrentModelId}
               usage={usage}
             />
           )}
@@ -207,7 +214,7 @@ export function Chat({
         votes={votes}
         isReadonly={isReadonly}
         selectedVisibilityType={visibilityType}
-        selectedModelId={initialChatModel}
+        selectedModelId={currentModelId}
       />
 
       <AlertDialog

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -64,6 +64,7 @@ function PureMultimodalInput({
   className,
   selectedVisibilityType,
   selectedModelId,
+  onModelChange,
   usage,
 }: {
   chatId: string;
@@ -79,6 +80,7 @@ function PureMultimodalInput({
   className?: string;
   selectedVisibilityType: VisibilityType;
   selectedModelId: string;
+  onModelChange?: (modelId: string) => void;
   usage?: AppUsage;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -353,7 +355,7 @@ function PureMultimodalInput({
               status={status}
               selectedModelId={selectedModelId}
             />
-            <ModelSelectorCompact selectedModelId={selectedModelId} />
+            <ModelSelectorCompact selectedModelId={selectedModelId} onModelChange={onModelChange} />
           </PromptInputTools>
 
           {status === 'submitted' ? (
@@ -418,10 +420,16 @@ const AttachmentsButton = memo(PureAttachmentsButton);
 
 function PureModelSelectorCompact({
   selectedModelId,
+  onModelChange,
 }: {
   selectedModelId: string;
+  onModelChange?: (modelId: string) => void;
 }) {
   const [optimisticModelId, setOptimisticModelId] = useState(selectedModelId);
+
+  useEffect(() => {
+    setOptimisticModelId(selectedModelId);
+  }, [selectedModelId]);
 
   const selectedModel = chatModels.find(
     (model) => model.id === optimisticModelId,
@@ -434,6 +442,7 @@ function PureModelSelectorCompact({
         const model = chatModels.find((m) => m.name === modelName);
         if (model) {
           setOptimisticModelId(model.id);
+          onModelChange?.(model.id);
           startTransition(() => {
             saveChatModelAsCookie(model.id);
           });


### PR DESCRIPTION
## background

users reported that model selection wasn't persisting correctly when switching between models (e.g., vision → reasoning → vision). the chat component was using the initial model value from page load instead of tracking the current selection, causing messages to be sent with the wrong model

## summary

- fix model selection persistence by tracking current model state with ref

## verification

- model selection persists correctly when switching between models
- switching from vision → reasoning → vision now correctly uses vision model for the final message

## tasks

- [x] add currentModelId state and ref tracking
- [x] update prepareSendMessagesRequest to use ref
- [x] add onModelChange callback to sync model selection
- [x] update MultimodalInput to propagate model changes

## future work

- consider migrating model selection to a global state management solution if complexity increases
