### PR TITLE
docs: add AI Gateway setup link to .env.example (#1210)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,10 @@
 AUTH_SECRET=****
 
 # The following keys below are automatically created and
-# added to your environment when you deploy on vercel
+# added to your environment when you deploy on Vercel
 
-# AI Gateway API Key (required for non-Vercel deployments)
+# Instructions to create an AI Gateway API key here: https://vercel.com/ai-gateway 
+# API key required for non-Vercel deployments
 # For Vercel deployments, OIDC tokens are used automatically
 AI_GATEWAY_API_KEY=****
 


### PR DESCRIPTION
Adds AI Gateway setup link to `.env.example` to help new contributors get started quickly.