### PR TITLE
Unclebigbay/add message queue

### DIFF
--- a/components/elements/queue.tsx
+++ b/components/elements/queue.tsx
@@ -15,6 +15,8 @@ export interface QueuePanelProps {
 function PureQueuePanel({ items, isOpen, onToggle, onRemove }: QueuePanelProps) {
   if (items.length === 0) return null;
 
+  // trigger commit to repo
+
   return (
     <div className='rounded-t-xl border border-border border-b-0 bg-background px-3 pt-2 pb-2 shadow-xs'>
       <button

--- a/components/elements/queue.tsx
+++ b/components/elements/queue.tsx
@@ -34,10 +34,8 @@ function PureQueuePanel({ items, isOpen, onToggle, onRemove }: QueuePanelProps) 
           {items.map((parts, index) => {
             const summary = (() => {
               const textParts = parts.filter((p) => 'type' in p && p.type === 'text') as Array<{ type: 'text'; text: string }>;
-              const fileParts = parts.filter((p) => 'type' in p && p.type === 'file') as Array<{ type: 'file'; name?: string }>;
               const text = textParts.map((p) => p.text).join(' ').trim();
               if (text) return text;
-              if (fileParts.length > 0) return `${fileParts.length} attachment${fileParts.length > 1 ? 's' : ''}`;
               return '(queued message)';
             })();
 

--- a/components/elements/queue.tsx
+++ b/components/elements/queue.tsx
@@ -15,8 +15,6 @@ export interface QueuePanelProps {
 function PureQueuePanel({ items, isOpen, onToggle, onRemove }: QueuePanelProps) {
   if (items.length === 0) return null;
 
-  // trigger commit to repo
-
   return (
     <div className='rounded-t-xl border border-border border-b-0 bg-background px-3 pt-2 pb-2 shadow-xs'>
       <button

--- a/components/elements/queue.tsx
+++ b/components/elements/queue.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import type { ChatMessage } from '@/lib/types';
+import { Trash2 } from 'lucide-react';
+import { memo } from 'react';
+import { ChevronDownIcon } from '../icons';
+
+export interface QueuePanelProps {
+  items: Array<ChatMessage['parts']>;
+  isOpen: boolean;
+  onToggle: () => void;
+  onRemove: (index: number) => void;
+}
+
+function PureQueuePanel({ items, isOpen, onToggle, onRemove }: QueuePanelProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className='rounded-t-xl border border-border border-b-0 bg-background px-3 pt-2 pb-2 shadow-xs'>
+      <button
+        type="button"
+        className='flex w-full items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-left text-sm font-medium text-muted-foreground hover:bg-muted'
+        onClick={onToggle}
+      >
+        <span>
+          {items.length} Queued
+        </span>
+        <span className={isOpen ? 'rotate-180 transition-transform' : 'transition-transform'}>
+          <ChevronDownIcon size={14} />
+        </span>
+      </button>
+      {isOpen && (
+        <ul className='mt-2 max-h-40 overflow-y-auto pr-1'>
+          {items.map((parts, index) => {
+            const summary = (() => {
+              const textParts = parts.filter((p) => 'type' in p && p.type === 'text') as Array<{ type: 'text'; text: string }>;
+              const fileParts = parts.filter((p) => 'type' in p && p.type === 'file') as Array<{ type: 'file'; name?: string }>;
+              const text = textParts.map((p) => p.text).join(' ').trim();
+              if (text) return text;
+              if (fileParts.length > 0) return `${fileParts.length} attachment${fileParts.length > 1 ? 's' : ''}`;
+              return '(queued message)';
+            })();
+
+            return (
+              <li key={index} className='group flex items-center gap-2 py-1 px-2 text-sm text-muted-foreground rounded-md hover:bg-muted transition-colors'>
+                <span className='mt-1 inline-block size-2.5 rounded-full border border-muted-foreground/50'></span>
+                <span className='line-clamp-1 break-words grow'>{summary}</span>
+                <button
+                  type='button'
+                  className='invisible group-hover:visible rounded p-1 text-muted-foreground hover:text-foreground hover:bg-muted-foreground/10'
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onRemove(index);
+                  }}
+                  aria-label='Remove from queue'
+                >
+                  <Trash2 size={12} />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export const QueuePanel = memo(PureQueuePanel);
+
+

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -347,7 +347,7 @@ function PureMultimodalInput({
       />
 
       <PromptInput
-        className={`${hasQueue ? 'rounded-b-xl rounded-t-none border-t-0' : 'rounded-xl'} border border-border bg-background shadow-xs transition-all duration-200 focus-within:border-border hover:border-muted-foreground/50`}
+        className={`${hasQueue ? 'rounded-b-xl rounded-t-none border-t-0' : 'rounded-xl'} p-3 border border-border bg-background shadow-xs transition-all duration-200 focus-within:border-border hover:border-muted-foreground/50`}
         onSubmit={(event) => {
           event.preventDefault();
           submitForm();

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -411,7 +411,7 @@ function PureMultimodalInput({
             />
             <ModelSelectorCompact selectedModelId={selectedModelId} />
           </PromptInputTools>
-          {status === 'submitted'&&!input.trim() ? (
+          {status === 'submitted' && !input.trim() ? (
             <StopButton stop={stop} setMessages={setMessages} />
           ) : (
             <PromptInputSubmit


### PR DESCRIPTION
### Summary
Adds a queued message UX to the chat input. While the AI is responding, new user messages are queued and automatically sent in order once the model becomes ready.

### Why
Previously, users had to wait until the AI finished responding before sending another message. This new UX improves flow and usability by letting users queue multiple thoughts without interruption.

### Screenshots
**1. Default (AI responding, queue collapsed)**
   <img width="3024" height="1726" alt="image" src="https://github.com/user-attachments/assets/8681b574-db57-4e0b-be03-830940866f03" />
**2. Expanded (view all queued messages)**
   <img width="3024" height="1726" alt="image" src="https://github.com/user-attachments/assets/114b570d-436f-421c-8d12-0b12ebbc225b" />
**3. Hover state (remove a queued message)**
   <img width="3024" height="1726" alt="image" src="https://github.com/user-attachments/assets/e63ab1a3-5c39-41c7-a09b-b6fe113b19da" />
### Key Features
- Collapsible queue panel above the input that visually merges with the input card.
- Auto-flush: sends one queued message at a time when `status === 'ready'`.
- Per-item removal from the queue.

### Notes
- Stop button remains visible only when streaming and input is empty (intentional UX).
- Queue UI extracted to `components/elements/queue.tsx`; state/side-effects remain in `components/multimodal-input.tsx`.
