### PR TITLE
Fix/katex rendering issue 1213

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
+
 # local env files
 .env.local
 .env.development.local

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,9 @@
 /* include utility classes in streamdown */
 @source '../node_modules/streamdown/dist/index.js';
 
+/* Add KaTeX CSS for math rendering */
+@import 'katex/dist/katex.min.css';
+
 /* custom variant for setting dark mode programmatically */
 @custom-variant dark (&:is(.dark, .dark *));
 


### PR DESCRIPTION
## Fix KaTeX Rendering Issue

### Problem
KaTeX rendering is broken for both inline math and math in tables, as reported in #1213. Mathematical expressions are not displaying with proper styling.

### Root Cause
The KaTeX JavaScript library is available via the `streamdown` package, but the KaTeX CSS stylesheet is missing. Without the CSS, math expressions render as unstyled HTML elements.

### Solution
Added the KaTeX CSS import to `app/globals.css`:
```css
@import 'katex/dist/katex.min.css';
```

### Testing
- ✅ Inline math: `$E = mc^2$` now renders properly
- ✅ Block math: `$$\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}$$` displays correctly
- ✅ Math in tables renders with proper styling
- ✅ Dark/light mode compatibility maintained

### Changes
- `app/globals.css`: Added KaTeX CSS import

Fixes #1213 