### PR TITLE
fix: Missing focus outlines

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -426,15 +426,14 @@ function PureModelSelectorCompact({
       }}
       value={selectedModel?.name}
     >
-      <Trigger
-        className="flex h-8 items-center gap-2 rounded-lg border-0 bg-background px-2 text-foreground shadow-none transition-colors hover:bg-accent focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0"
-        type="button"
-      >
-        <CpuIcon size={16} />
-        <span className="hidden font-medium text-xs sm:block">
-          {selectedModel?.name}
-        </span>
-        <ChevronDownIcon size={16} />
+      <Trigger asChild>
+        <Button variant="ghost" className="px-2">
+          <CpuIcon size={16} />
+          <span className="hidden font-medium text-xs sm:block">
+            {selectedModel?.name}
+          </span>
+          <ChevronDownIcon size={16} />
+        </Button>
       </Trigger>
       <PromptInputModelSelectContent className="min-w-[260px] p-0">
         <div className="flex flex-col gap-px">

--- a/components/visibility-selector.tsx
+++ b/components/visibility-selector.tsx
@@ -69,7 +69,7 @@ export function VisibilitySelector({
         )}
       >
         <Button
-          className="hidden h-8 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 md:flex md:h-fit md:px-2"
+          className="hidden h-8 md:flex md:h-fit md:px-2"
           data-testid="visibility-selector"
           variant="outline"
         >


### PR DESCRIPTION
Ensure both PureModelSelectorCompact and VisibilitySelector have visible outlines when focus visible.

| BEFORE | AFTER |
|--------|--------|
| <img width="180" height="66" alt="Screenshot 2025-09-29 at 8 56 55 PM" src="https://github.com/user-attachments/assets/0ba2aedc-30ee-468e-9d32-0efc01812793" /> | <img width="175" height="90" alt="Screenshot 2025-09-29 at 8 55 44 PM" src="https://github.com/user-attachments/assets/04d0df4f-bad2-49ca-8a81-787990483cff" /> |
| <img width="221" height="81" alt="Screenshot 2025-09-29 at 8 57 14 PM" src="https://github.com/user-attachments/assets/ceb216b3-49d6-469b-a580-96eb04038cc1" /> | <img width="262" height="94" alt="Screenshot 2025-09-29 at 8 56 06 PM" src="https://github.com/user-attachments/assets/4ef4750e-67c6-4877-8b0a-897320bbe6cb" /> | 