### PR TITLE
Fixing next/image` Un-configured Host error while uploading images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,7 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         //https://nextjs.org/docs/messages/next-image-unconfigured-host
-        hostname: "YourBlobURL.public.blob.vercel-storage.com",
+        hostname: "*.public.blob.vercel-storage.com",
       },
     ],
   },


### PR DESCRIPTION
When I upload an Image I get the below error 

``next/image` Un-configured Host
`

The error occurs because One of your pages that leverages the next/image component, passed a src value that uses a hostname in the URL that isn't defined in the images.remotePatterns in next.config.js., added a simple fix to the next.config.ts as per https://nextjs.org/docs/messages/next-image-unconfigured-host, should not impact anything else