### PR TITLE
refactor: remove redundant and() in query condition

### DIFF
--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -394,7 +394,7 @@ export async function getSuggestionsByDocumentId({
     return await db
       .select()
       .from(suggestion)
-      .where(and(eq(suggestion.documentId, documentId)));
+      .where(eq(suggestion.documentId, documentId));
   } catch (_error) {
     throw new ChatSDKError(
       "bad_request:database",


### PR DESCRIPTION
Simplifies query to use a single eq() condition without unnecessary logical wrapper. No functional changes.