### PR TITLE
fix: prevent content loss when re-clicking active document

### DIFF
--- a/components/document.tsx
+++ b/components/document.tsx
@@ -55,15 +55,15 @@ function PureDocumentToolResult({
           height: rect.height,
         };
 
-        setArtifact({
+        setArtifact((currentArtifact) => ({
           documentId: result.id,
           kind: result.kind,
-          content: "",
+          content: currentArtifact.content,
           title: result.title,
           isVisible: true,
           status: "idle",
           boundingBox,
-        });
+        }));
       }}
       type="button"
     >


### PR DESCRIPTION
Fixed bug where re-clicking an active document cleared its content by preserving `currentArtifact.content` in `DocumentToolResult`.

Bug: https://jam.dev/c/f8856bcb-7ff6-475c-b206-60083f79fba9
Fixed: https://jam.dev/c/796b25de-cf34-49d0-a947-3418cb800eb0