### PR TITLE
Fix: generate title from user message — use only text parts

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -4,11 +4,13 @@ import { generateText, type UIMessage } from "ai";
 import { cookies } from "next/headers";
 import type { VisibilityType } from "@/components/visibility-selector";
 import { myProvider } from "@/lib/ai/providers";
+import { titlePrompt } from "@/lib/ai/prompts";
 import {
   deleteMessagesByChatIdAfterTimestamp,
   getMessageById,
   updateChatVisiblityById,
 } from "@/lib/db/queries";
+import { getTextFromMessage } from "@/lib/utils";
 
 export async function saveChatModelAsCookie(model: string) {
   const cookieStore = await cookies();
@@ -20,17 +22,10 @@ export async function generateTitleFromUserMessage({
 }: {
   message: UIMessage;
 }) {
- 
-  let userMessage = message.parts.filter((part) => part.type === "text").map((part) => part.text).join("\n");
-
   const { text: title } = await generateText({
     model: myProvider.languageModel("title-model"),
-    system: `\n
-    - you will generate a short title based on the first message a user begins a conversation with
-    - ensure it is not more than 80 characters long
-    - the title should be a summary of the user's message
-    - do not use quotes or colons`,
-    prompt: userMessage,
+    system: titlePrompt,
+    prompt: getTextFromMessage(message),
   });
 
   return title;

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -112,3 +112,9 @@ export const updateDocumentPrompt = (
 
 ${currentContent}`;
 };
+
+export const titlePrompt = `\n
+    - you will generate a short title based on the first message a user begins a conversation with
+    - ensure it is not more than 80 characters long
+    - the title should be a summary of the user's message
+    - do not use quotes or colons`

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -108,9 +108,9 @@ export function convertToUIMessages(messages: DBMessage[]): ChatMessage[] {
   }));
 }
 
-export function getTextFromMessage(message: ChatMessage): string {
+export function getTextFromMessage(message: ChatMessage | UIMessage): string {
   return message.parts
     .filter((part) => part.type === 'text')
-    .map((part) => part.text)
+    .map((part) => (part as { type: 'text'; text: string}).text)
     .join('');
 }


### PR DESCRIPTION
Fixes: #1278

This PR ensures we only send the user's visible text to the LLM when generating a title, rather than the whole `UIMessage` object. It extracts text parts and joins them with newlines before calling `generateText`.

Notes:
- Kept the change small and focused — no behavioral changes beyond the prompt content.
- If maintainers prefer a more defensive implementation (guards, trimming, cap), I can update the PR.
