### PR TITLE
fix: prevent closed artifacts from reopening when switching chats

### DIFF
--- a/components/data-stream-handler.tsx
+++ b/components/data-stream-handler.tsx
@@ -6,18 +6,17 @@ import { artifactDefinitions } from "./artifact";
 import { useDataStream } from "./data-stream-provider";
 
 export function DataStreamHandler() {
-  const { dataStream } = useDataStream();
+  const { dataStream,setDataStream } = useDataStream();
 
   const { artifact, setArtifact, setMetadata } = useArtifact();
-  const lastProcessedIndex = useRef(-1);
 
   useEffect(() => {
     if (!dataStream?.length) {
       return;
     }
 
-    const newDeltas = dataStream.slice(lastProcessedIndex.current + 1);
-    lastProcessedIndex.current = dataStream.length - 1;
+    const newDeltas = dataStream.slice();
+    setDataStream([]);
 
     for (const delta of newDeltas) {
       const artifactDefinition = artifactDefinitions.find(


### PR DESCRIPTION
When a user creates an artifact and closes its window, switching to another chat causes the artifact to reopen automatically.

This behavior only happens in the same session; refreshing the page prevents it.