### PR TITLE
Tests: recover missing test elements

### DIFF
--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -52,6 +52,7 @@ export function PureMessageActions({
           {setMode && (
             <Action
               className="-left-10 absolute top-0 opacity-0 transition-opacity group-hover/message:opacity-100"
+              data-testid="message-edit-button"
               onClick={() => setMode("edit")}
               tooltip="Edit"
             >

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -333,6 +333,7 @@ function PureMultimodalInput({
               className="size-8 rounded-full bg-primary text-primary-foreground transition-colors duration-200 hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground"
               disabled={!input.trim() || uploadQueue.length > 0}
               status={status}
+	      data-testid="send-button"
             >
               <ArrowUpIcon size={14} />
             </PromptInputSubmit>

--- a/components/preview-attachment.tsx
+++ b/components/preview-attachment.tsx
@@ -35,7 +35,10 @@ export const PreviewAttachment = ({
       )}
 
       {isUploading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+        <div
+	  className="absolute inset-0 flex items-center justify-center bg-black/50"
+	  data-testid="input-attachment-loader"
+	>
           <Loader size={16} />
         </div>
       )}


### PR DESCRIPTION
Fix Playwright chat tests by recovering lost test elements

3 missing elements added, resulting in more tests that now pass

Run tests with `pnpm test` or `pnpm exec playwright test tests/e2e/chat.test.ts --project=e2e`


### Example

One missing test element was `data-testid` for `send-button` in file `components/multimodal-input.tsx`

It is required for basic chat tests to run, in `tests/pages/chat.ts`:
```js
 get sendButton() {
    return this.page.getByTestId("send-button");
  }
```
The similar `stop-button` is present and works, around line 467 in `components/multimodal-input.tsx`

The `send-button` was present in 9dd9a9898c0995bd14a6a154f0e54a33f48b1f69 but inadvertently removed in #1155 