### PR TITLE
fix(ui): adjust user message bubble styling for multiline code and proper alignment

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -126,7 +126,7 @@ const PurePreviewMessage = ({
                   <div key={key}>
                     <MessageContent
                       className={cn({
-                        "w-fit break-words rounded-2xl px-3 py-2 text-right text-white":
+                        "w-fit-break-words rounded-2xl px-3 py-2 text-white whitespace-pre-wrap":
                           message.role === "user",
                         "bg-transparent px-0 py-0 text-left":
                           message.role === "assistant",


### PR DESCRIPTION
### Summary
Fixes message bubble styling issue for user messages containing multi-line code or long text.

### Changes
- Replaced `break-words` with `whitespace-pre-wrap` to correctly render line breaks.
- Removed `text-right` to align multi-line code properly.
- Kept `rounded-2xl` and padding for consistent bubble style.

### Before
Long code blocks were right-aligned and displayed as a single line.
<img width="994" height="368" alt="截圖 2025-11-07 上午11 04 29" src="https://github.com/user-attachments/assets/06601f7e-df48-4a6e-a810-9b0916ef23d4" />
<img width="1094" height="537" alt="截圖 2025-11-07 上午11 04 11" src="https://github.com/user-attachments/assets/d7666bba-b64e-42b1-8b00-9e1a48fac1d2" />


### After
Code and text now preserve line breaks and align naturally.
<img width="1021" height="502" alt="截圖 2025-11-07 上午11 04 53" src="https://github.com/user-attachments/assets/b206e430-5478-4c51-8768-7b876a98ef34" />

<img width="1077" height="398" alt="截圖 2025-11-07 上午11 04 58" src="https://github.com/user-attachments/assets/efff61a8-c409-4bb4-9197-139d35885bcb" />


