### PR TITLE
Feat/web search integration

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -24,6 +24,7 @@ import { MessageEditor } from "./message-editor";
 import { MessageReasoning } from "./message-reasoning";
 import { PreviewAttachment } from "./preview-attachment";
 import { Weather } from "./weather";
+import { SearchResults, SearchingIndicator } from "./search-results";
 
 const PurePreviewMessage = ({
   chatId,
@@ -52,6 +53,18 @@ const PurePreviewMessage = ({
 
   useDataStream();
 
+  // Check if search results are in the message parts
+  const searchResultsPart = message.parts?.find(
+    (part) => part.type === "data-searchResults"
+  );
+
+  const searchResults =
+    searchResultsPart && "data" in searchResultsPart && searchResultsPart.data
+      ? searchResultsPart.data
+      : undefined;
+
+  // Check if we should show searching indicator (message is loading and assistant role)
+  const isSearching = isLoading && message.role === "assistant" && (!searchResults || searchResults.length === 0);
   return (
     <motion.div
       animate={{ opacity: 1 }}
@@ -103,6 +116,16 @@ const PurePreviewMessage = ({
                   key={attachment.url}
                 />
               ))}
+            </div>
+          )}
+
+          {message.role === "assistant" && (isSearching || searchResults) && (
+            <div className="w-full">
+              {searchResults ? (
+                <SearchResults searchResult={searchResults} />
+              ) : (
+                <SearchingIndicator />
+              )}
             </div>
           )}
 

--- a/components/search-results.tsx
+++ b/components/search-results.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { GlobeIcon } from "lucide-react";
+import type { SearchSource } from "@/lib/types";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon } from "lucide-react";
+import { useState } from "react";
+import Link from "next/link";
+
+
+export function SearchResults({ searchResult }: { searchResult: SearchSource[] }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (!searchResult || !Array.isArray(searchResult) || searchResult.length === 0) {
+    return null;
+  }
+
+  return (
+    <Collapsible
+      className="not-prose w-full"
+      onOpenChange={setIsOpen}
+      open={isOpen}
+    >
+      <CollapsibleTrigger className="flex w-full min-w-0 items-center gap-2 text-muted-foreground text-xs transition-colors hover:text-foreground">
+        <GlobeIcon className="size-4 shrink-0" />
+        <span className="font-medium">
+          Searched web
+        </span>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className="text-muted-foreground">
+            {searchResult.length} {searchResult.length === 1 ? "result" : "results"}
+          </span>
+          <ChevronDownIcon
+            className={cn(
+              "size-3 text-muted-foreground transition-transform",
+              isOpen && "rotate-180"
+            )}
+          />
+        </div>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="mt-3 data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in">
+        <div className="grid gap-1.5">
+          {searchResult.map((source, index) => (
+            <Link
+              className="flex items-center gap-2 text-xs transition-colors hover:text-foreground min-w-0 overflow-hidden animate-in fade-in-0 slide-in-from-top-1"
+              href={source.url}
+              key={index}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <div className="flex size-4 shrink-0 items-center justify-center overflow-hidden rounded">
+                {source.favicon ? (
+                  <img
+                    alt=""
+                    className="size-4"
+                    src={source.favicon}
+                    onError={(e) => {
+                      e.currentTarget.style.display = "none";
+                    }}
+                  />
+                ) : (
+                  <GlobeIcon className="size-3 text-muted-foreground" />
+                )}
+              </div>
+              <span className="truncate font-medium text-foreground">
+                {source.title}
+              </span>
+              <span className="shrink-0 truncate text-muted-foreground max-w-[120px]">
+                {new URL(source.url).hostname.replace('www.', '')}
+              </span>
+            </Link>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function SearchingIndicator() {
+  return (
+    <div className="flex w-full items-center gap-2 text-muted-foreground text-xs animate-in fade-in-0">
+      <GlobeIcon className="size-4 shrink-0 animate-pulse" />
+      <span>Searching the web</span>
+    </div>
+  );
+}

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -4,6 +4,9 @@ export type ChatModel = {
   id: string;
   name: string;
   description: string;
+  capabilities?: {
+    webSearch?: boolean;
+  };
 };
 
 export const chatModels: ChatModel[] = [
@@ -11,11 +14,26 @@ export const chatModels: ChatModel[] = [
     id: "chat-model",
     name: "Grok Vision",
     description: "Advanced multimodal model with vision and text capabilities",
+    capabilities: {
+      webSearch: true,
+    },
   },
   {
     id: "chat-model-reasoning",
     name: "Grok Reasoning",
     description:
       "Uses advanced chain-of-thought reasoning for complex problems",
+    capabilities: {
+      webSearch: true,
+    },
   },
 ];
+
+export function getModelCapabilities(modelId: string) {
+  const model = chatModels.find((m) => m.id === modelId);
+  return model?.capabilities || {};
+}
+
+export function supportsWebSearch(modelId: string): boolean {
+  return getModelCapabilities(modelId).webSearch === true;
+}

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -5,6 +5,7 @@ import {
   wrapLanguageModel,
 } from "ai";
 import { isTestEnvironment } from "../constants";
+import { supportsWebSearch } from "./models";
 
 export const myProvider = isTestEnvironment
   ? (() => {
@@ -34,3 +35,24 @@ export const myProvider = isTestEnvironment
         "artifact-model": gateway.languageModel("xai/grok-2-1212"),
       },
     });
+
+/**
+ * Builds provider-specific options based on model capabilities
+ */
+export function buildProviderOptions(modelId: string) {
+  if (!supportsWebSearch(modelId)) {
+    return;
+  }
+
+  const options = {
+    xai: {
+      searchParameters: {
+        mode: "auto" as const,
+        returnCitations: true,
+        maxSearchResults: 10,
+      },
+    },
+  };
+
+  return options;
+}

--- a/lib/db/migrations/0008_left_giant_girl.sql
+++ b/lib/db/migrations/0008_left_giant_girl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Message_v2" ADD COLUMN "searchResults" jsonb;

--- a/lib/db/migrations/meta/0008_snapshot.json
+++ b/lib/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,577 @@
+{
+  "id": "e13f85ed-4f6c-4b13-8b2e-a946025162fa",
+  "prevId": "097660a7-976a-4b3e-8ebb-79312e3ece6f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searchResults": {
+          "name": "searchResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1757362773211,
       "tag": "0007_flowery_ben_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1762604749298,
+      "tag": "0008_left_giant_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -58,6 +58,7 @@ export const message = pgTable("Message_v2", {
   role: varchar("role").notNull(),
   parts: json("parts").notNull(),
   attachments: json("attachments").notNull(),
+  searchResults: jsonb("searchResults"),
   createdAt: timestamp("createdAt").notNull(),
 });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,6 +30,13 @@ export type ChatTools = {
   requestSuggestions: requestSuggestionsTool;
 };
 
+export type SearchSource = {
+  title: string;
+  url: string;
+  favicon?: string;
+};
+
+
 export type CustomUIDataTypes = {
   textDelta: string;
   imageDelta: string;
@@ -43,6 +50,7 @@ export type CustomUIDataTypes = {
   clear: null;
   finish: null;
   usage: AppUsage;
+  searchResults: SearchSource[];
 };
 
 export type ChatMessage = UIMessage<


### PR DESCRIPTION
I added web search functionality using xAI's built-in search capabilities. 

This PR integrates xAI's web search feature (from the SDK) into the chatbot, allowing Grok models to search the web and cite sources in their responses.

Changes made

Backend:
- Added search parameter configuration in `lib/ai/providers.ts` (mode: auto, max 10 results)
- Updated message schema to store search results
- Result processing and deduplication in the chat route

Frontend:
- Created `SearchResults` component with collapsible source list
- Added `SearchingIndicator` for loading state
- Results display into message

**1.** 
<img width="915" height="211" alt="Screenshot 2025-11-09 at 12 10 04 PM" src="https://github.com/user-attachments/assets/6b18118c-5671-477c-a1a1-29aec0ac84df" />
**2.** 
<img width="904" height="300" alt="Screenshot 2025-11-09 at 12 10 26 PM" src="https://github.com/user-attachments/assets/ce94b073-8ac3-446e-b357-255bf6be1b9a" />
**3.** 
<img width="908" height="626" alt="Screenshot 2025-11-09 at 12 10 41 PM" src="https://github.com/user-attachments/assets/0c6796dc-4a17-4188-983c-666581e8d215" />


Notes:
- Configured to work with both chat-model (Grok Vision) and chat-model-reasoning (Grok Reasoning)
- Includes URL deduplication as a workaround for https://github.com/vercel/ai/issues/9771

Tested with various queries that benefit from web search:
- Current events ("latest news about...")

Happy to make any changes or adjustments based on feedback!