### PR TITLE
chore: remove custom generateUUID implementation

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,7 @@ import { twMerge } from 'tailwind-merge';
 import type { DBMessage, Document } from '@/lib/db/schema';
 import { ChatSDKError, type ErrorCode } from './errors';
 import type { ChatMessage, ChatTools, CustomUIDataTypes } from './types';
+import { v4 as uuidv4 } from 'uuid';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -56,11 +57,7 @@ export function getLocalStorage(key: string) {
 }
 
 export function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+  return uuidv4();
 }
 
 type ResponseMessageWithoutId = CoreToolMessage | CoreAssistantMessage;


### PR DESCRIPTION
Not sure why this was here, but noticed it while refactoring some old utils code that I was working on personally. It's almost 30 times slower, less cryptographically secure, and the `uuid` library is already included as a subdependency so it's not even saving any disk footprint.