### PR TITLE
Renamed misleading variable for clarity in sidebar-history

### DIFF
--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -88,13 +88,13 @@ export function getChatHistoryPaginationKey(
     return `/api/history?limit=${PAGE_SIZE}`;
   }
 
-  const firstChatFromPage = previousPageData.chats.at(-1);
+  const lastChatFromPage = previousPageData.chats.at(-1);
 
-  if (!firstChatFromPage) {
+  if (!lastChatFromPage) {
     return null;
   }
 
-  return `/api/history?ending_before=${firstChatFromPage.id}&limit=${PAGE_SIZE}`;
+  return `/api/history?ending_before=${lastChatFromPage.id}&limit=${PAGE_SIZE}`;
 }
 
 export function SidebarHistory({ user }: { user: User | undefined }) {


### PR DESCRIPTION
The variable name `firstChatFromPage` is misleading since `at(-1)` gets the last element of the array, not the first