### PR TITLE
fix: `PromptInputTextarea` now actually handles its own damn resize logic

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -83,24 +83,6 @@ function PureMultimodalInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
 
-  const adjustHeight = useCallback(() => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "44px";
-    }
-  }, []);
-
-  useEffect(() => {
-    if (textareaRef.current) {
-      adjustHeight();
-    }
-  }, [adjustHeight]);
-
-  const resetHeight = useCallback(() => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "44px";
-    }
-  }, []);
-
   const [localStorageInput, setLocalStorageInput] = useLocalStorage(
     "input",
     ""
@@ -112,11 +94,10 @@ function PureMultimodalInput({
       // Prefer DOM value over localStorage to handle hydration
       const finalValue = domValue || localStorageInput || "";
       setInput(finalValue);
-      adjustHeight();
     }
     // Only run once after hydration
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [adjustHeight, localStorageInput, setInput]);
+  }, [localStorageInput, setInput]);
 
   useEffect(() => {
     setLocalStorageInput(input);
@@ -150,7 +131,6 @@ function PureMultimodalInput({
 
     setAttachments([]);
     setLocalStorageInput("");
-    resetHeight();
     setInput("");
 
     if (width && width > 768) {
@@ -165,7 +145,6 @@ function PureMultimodalInput({
     setLocalStorageInput,
     width,
     chatId,
-    resetHeight,
   ]);
 
   const uploadFile = useCallback(async (file: File) => {


### PR DESCRIPTION
This component was accepting `minHeight/maxHeight/disableAutoResize` props and doing absolutely nothing with them. Meanwhile, the parent Composer/MultimodalInput had `adjustHeight()` and `resetHeight()` functions that both just hardcoded `"44px"` and called it a day 🥂.

What's fixed:
- Implemented actual autoresize logic inside `PromptInputTextarea`
- Forward refs properly so parents can access textarea without fighting us
- Actually use the min/max height props we've been accepting
- Implement resizeOnNewLinesOnly prop (it existed but did nothing before)
- Remove manual height manipulation from Composer - let the component handle it
- No breaking changes - all existing props still work
- Miscellaneous 

Changes in MultimodalInput:
- Removed `adjustHeight()` and `resetHeight()` functions
- Removed manual `ref.current.style.height` manipulation
- Component now properly uses PromptInputTextarea's built-in resize

Changes in `PromptInputTextarea`:
- Added `forwardRef` support
- Implemented proper autoresize with `useEffect`
- Apply `minHeight/maxHeight` via inline styles
- Track newline count for `resizeOnNewLinesOnly` optimization
- Single resize per change (no double execution)

The textarea now grows and shrinks nicely.

This PR will be followed by a fix (New PR) addressing the `scroll-to-bottom` button that currently doesn't respond to the auto-resizing text area input.

> **PS: Thank you for all the amazing work on this project. I truly appreciate the efforts of everyone involved and I'm committed to supporting Vercel and all its projects. Your dedication makes a real difference!**

Edit: 
See https://github.com/vercel/ai-chatbot/pull/1322 for supplementary fixes