### PR TITLE
Shared scroll state support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -142,6 +142,22 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  --animate-floating-action: floatingAction 2s ease-in-out infinite;
+
+  @keyframes floatingAction {
+    0% {
+        transform: translateY(calc(-4px*1));
+    }
+
+    50% {
+        transform: translateY(calc(4px*1));
+    }
+
+    to {
+        transform: translateY(calc(-4px*1));
+    }
+  }
 }
 
 /*

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -32,6 +32,7 @@ import { MultimodalInput } from "./multimodal-input";
 import { getChatHistoryPaginationKey } from "./sidebar-history";
 import { toast } from "./toast";
 import type { VisibilityType } from "./visibility-selector";
+import { ScrollToBottomProvider } from "@/hooks/use-scroll-to-bottom";
 
 export function Chat({
   id,
@@ -156,6 +157,7 @@ export function Chat({
 
   return (
     <>
+      <ScrollToBottomProvider>
       <div className="overscroll-behavior-contain flex h-dvh min-w-0 touch-pan-y flex-col bg-background">
         <ChatHeader
           chatId={id}
@@ -214,7 +216,7 @@ export function Chat({
         stop={stop}
         votes={votes}
       />
-
+      </ScrollToBottomProvider>
       <AlertDialog
         onOpenChange={setShowCreditCardAlert}
         open={showCreditCardAlert}

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -36,11 +36,10 @@ function PureMessages({
   const {
     containerRef: messagesContainerRef,
     endRef: messagesEndRef,
-    isAtBottom,
-    scrollToBottom,
     hasSentMessage,
   } = useMessages({
     status,
+     useScrollContext: true,
   });
 
   useDataStream();
@@ -101,17 +100,6 @@ function PureMessages({
           />
         </ConversationContent>
       </Conversation>
-
-      {!isAtBottom && (
-        <button
-          aria-label="Scroll to bottom"
-          className="-translate-x-1/2 absolute bottom-40 left-1/2 z-10 rounded-full border bg-background p-2 shadow-lg transition-colors hover:bg-muted"
-          onClick={() => scrollToBottom("smooth")}
-          type="button"
-        >
-          <ArrowDownIcon className="size-4" />
-        </button>
-      )}
     </div>
   );
 }

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -46,6 +46,8 @@ import { PreviewAttachment } from "./preview-attachment";
 import { SuggestedActions } from "./suggested-actions";
 import { Button } from "./ui/button";
 import type { VisibilityType } from "./visibility-selector";
+import { ArrowDownIcon } from "lucide-react";
+import { useScrollToBottomPersist } from "@/hooks/use-scroll-to-bottom";
 
 function PureMultimodalInput({
   chatId,
@@ -82,6 +84,7 @@ function PureMultimodalInput({
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
+  const { isAtBottom, scrollToBottom } = useScrollToBottomPersist(true);
 
   const [localStorageInput, setLocalStorageInput] = useLocalStorage(
     "input",
@@ -267,6 +270,18 @@ function PureMultimodalInput({
 
   return (
     <div className={cn("relative flex w-full flex-col gap-4", className)}>
+
+      {!isAtBottom && (
+        <button
+          aria-label="Scroll to bottom"
+          className="animate-floating-action mx-auto cursor-pointer -translate-x-1/2 -translate-y-14 absolute bottom-[inherit] left-1/2 z-10 rounded-full border bg-background p-2 shadow-lg transition-colors hover:bg-muted"
+          onClick={() => scrollToBottom("smooth")}
+          type="button"
+        >
+          <ArrowDownIcon className="size-4" />
+        </button>
+      )}
+      
       {messages.length === 0 &&
         attachments.length === 0 &&
         uploadQueue.length === 0 && (

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -83,24 +83,6 @@ function PureMultimodalInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
 
-  const adjustHeight = useCallback(() => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "44px";
-    }
-  }, []);
-
-  useEffect(() => {
-    if (textareaRef.current) {
-      adjustHeight();
-    }
-  }, [adjustHeight]);
-
-  const resetHeight = useCallback(() => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "44px";
-    }
-  }, []);
-
   const [localStorageInput, setLocalStorageInput] = useLocalStorage(
     "input",
     ""
@@ -112,11 +94,10 @@ function PureMultimodalInput({
       // Prefer DOM value over localStorage to handle hydration
       const finalValue = domValue || localStorageInput || "";
       setInput(finalValue);
-      adjustHeight();
     }
     // Only run once after hydration
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [adjustHeight, localStorageInput, setInput]);
+  }, [localStorageInput, setInput]);
 
   useEffect(() => {
     setLocalStorageInput(input);
@@ -150,7 +131,6 @@ function PureMultimodalInput({
 
     setAttachments([]);
     setLocalStorageInput("");
-    resetHeight();
     setInput("");
 
     if (width && width > 768) {
@@ -165,7 +145,6 @@ function PureMultimodalInput({
     setLocalStorageInput,
     width,
     chatId,
-    resetHeight,
   ]);
 
   const uploadFile = useCallback(async (file: File) => {

--- a/hooks/use-messages.tsx
+++ b/hooks/use-messages.tsx
@@ -1,12 +1,14 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { useEffect, useState } from "react";
 import type { ChatMessage } from "@/lib/types";
-import { useScrollToBottom } from "./use-scroll-to-bottom";
+import { useScrollToBottomPersist } from "./use-scroll-to-bottom";
 
 export function useMessages({
   status,
+    useScrollContext = false,
 }: {
   status: UseChatHelpers<ChatMessage>["status"];
+    useScrollContext?: boolean;
 }) {
   const {
     containerRef,
@@ -15,7 +17,7 @@ export function useMessages({
     scrollToBottom,
     onViewportEnter,
     onViewportLeave,
-  } = useScrollToBottom();
+  } = useScrollToBottomPersist(useScrollContext);
 
   const [hasSentMessage, setHasSentMessage] = useState(false);
 

--- a/hooks/use-scroll-to-bottom.tsx
+++ b/hooks/use-scroll-to-bottom.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { createContext, ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 
 type ScrollFlag = ScrollBehavior | false;
@@ -107,4 +107,34 @@ export function useScrollToBottom() {
     onViewportEnter,
     onViewportLeave,
   };
+}
+
+type ScrollToBottomContextValue = ReturnType<typeof useScrollToBottom> | null;
+
+const ScrollToBottomContext = createContext<ScrollToBottomContextValue>(null);
+
+export function ScrollToBottomProvider({ children }: { children: ReactNode }) {
+  const scrollToBottom = useScrollToBottom();
+
+  return (
+    <ScrollToBottomContext.Provider value={scrollToBottom}>
+      {children}
+    </ScrollToBottomContext.Provider>
+  );
+}
+
+export function useScrollToBottomPersist(singleton: boolean = false) {
+  const context = useContext(ScrollToBottomContext);
+  const localInstance = useScrollToBottom();
+
+  if (singleton) {
+    if (!context) {
+      throw new Error(
+        "useScrollToBottom(true) must be used within a ScrollToBottomProvider"
+      );
+    }
+    return context;
+  }
+
+  return localInstance;
 }


### PR DESCRIPTION
Added optional singleton mode to `useScrollToBottom` hook, allowing scroll state and controls to be shared across multiple components without creating duplicate instances.

Why this change:
* Please see: https://github.com/vercel/ai-chatbot/pull/1321
* `Scroll-to-bottom` button position is static and doesn't account for MultimodalInput's config/resize-ability
*  Previously, if you wanted to use the `scroll-to-bottom` button in a separate component (like `MultimodalInput`) from where the scrollable container lives (like MessagesContainer), you'd have to re-call the hook, which would create a new instance with its own state. This meant the button wouldn't reflect the actual scroll position.
* To make the scroller button pegged to a dynamic and config-friendly MultimodalInput size/height, something needed to be done


What's new:
- Added `ScrollToBottomProvider` context wrapper
- `useScrollToBottom` now accepts optional `singleton` boolean parameter
- When `singleton=true`, hook returns shared instance from provider
- When `singleton=false` (default), hook works exactly as before
- `useMessages` hook now takes the optional `singleton` prop
- `scroll-button` now animates as seen in [**v0.dev**](https://v0.dev/)

Usage:
1. Wrap your chat area with `<ScrollToBottomProvider>`
2. Use `useScrollToBottom(true)` in any child component to access shared state
3. **Existing code using `useScrollToBottom()` continues to work unchanged**

Benefits:
- Share scroll state across components (scroll button, auto-scroll, etc.)
- No breaking changes - fully backwards compatible
- Opt-in behavior - existing instances remain isolated by default
- Type-safe with helpful error messages

Example:
```tsx
<ScrollToBottomProvider>
  <MessagesContainer /> {/* assigns refs with useScrollToBottom(true) */}
  <MultimodalInput /> {/* accesses same instance with useScrollToBottom(true) */}
</ScrollToBottomProvider>
```

This makes it easy to place scroll controls anywhere in the component tree while maintaining a single source of truth for scroll state.

PS: This PR is a supplementary to https://github.com/vercel/ai-chatbot/pull/1321