### PR TITLE
optimize title generation speed

### DIFF
--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -521,6 +521,24 @@ export async function updateChatLastContextById({
   }
 }
 
+export async function updateChatTitleById({
+  chatId,
+  title,
+}: {
+  chatId: string;
+  title: string;
+}) {
+  try {
+    return await db
+      .update(chat)
+      .set({ title })
+      .where(eq(chat.id, chatId));
+  } catch (error) {
+    console.warn("Failed to update title for chat", chatId, error);
+    return;
+  }
+}
+
 export async function getMessageCountByUserId({
   id,
   differenceInHours,


### PR DESCRIPTION
I notice that the title-generation is block the response flow and become the bottle neck of response speed:
<img width="358" height="251" alt="Screenshot 2025-11-23 at 3 40 46 AM" src="https://github.com/user-attachments/assets/1c99656e-4777-4e66-8551-85f62e0a72d0" />

Problem
The chatbot API endpoint was experiencing severe performance issues with response times exceeding 84 seconds for new chat creation. The root cause was blocking title generation - the system waited for an LLM API call to generate a chat title before returning the stream response.

Solution
Made title generation non-blocking using a two-phase approach:
Generate a temporary title immediately from the first 60 characters of the user's message
Generate the LLM-based title asynchronously in the background and update when ready
This allows the chat stream to start immediately while the polished title is generated asynchronously.

Changes
lib/db/queries.ts
Added updateChatTitleById function to update chat titles after creation
app/(chat)/api/chat/route.ts
Replaced blocking await generateTitleFromUserMessage() with immediate temporary title generation
Added asynchronous real title generation that updates the chat when ready
Added imports for updateChatTitleById and getTextFromMessage

Performance Impact
Before: 19+ seconds (blocking on LLM title generation)
After: <1 second (immediate response with temporary title, real title updates in background)
