### PR TITLE
fix: memo comparison functions return false instead of true

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -305,7 +305,7 @@ export const PreviewMessage = memo(
       return false;
     }
 
-    return false;
+    return true;
   }
 );
 

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -137,5 +137,5 @@ export const Messages = memo(PureMessages, (prevProps, nextProps) => {
     return false;
   }
 
-  return false;
+  return true;
 });


### PR DESCRIPTION
In this PR I propose a fix for `React.memo` comparison functions in `Messages` and `PreviewMessage` that always returne `false`, effectively disabling memoization.

## Problem
Both components define a custom comparison function for `React.memo`, but they end with an unconditional `return false`.
Because the final line is always `false`, these components re-render on every parent update, regardless of whether the relevant props actually changed.

## Testing
Verified the app still updates when:
  - New messages are added.
  - Streaming status changes (e.g. `streaming` → `ready`).
  - Votes change.
Confirmed that, when props are unchanged, the components are now eligible to be skipped by `React.memo`, reducing unnecessary re-renders in longer chats.

