### PR TITLE
Fix the rendering error in the weather component Fixes #1339

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -176,6 +176,19 @@ const PurePreviewMessage = ({
               const widthClass = "w-[min(100%,450px)]";
 
               if (state === "output-available") {
+                const output = part.output as any;
+
+                if (output && "error" in output) {
+                  return (
+                    <div
+                      className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-500 dark:bg-red-950/50"
+                      key={toolCallId}
+                    >
+                      Error getting weather: {String(output.error)}
+                    </div>
+                  );
+                }
+
                 return (
                   <div className={widthClass} key={toolCallId}>
                     <Weather weatherAtLocation={part.output} />


### PR DESCRIPTION
### Background
#1339 

### Summary
The root cause of this problem is that the **open-meteo API** fails to recognize the city name **Washington DC**. As a result, the interface returns data that is not of the `weatherAtLocation` type, and the component does not handle this scenario accordingly, leading to a rendering error.

### Manual Verification
I used the same case and success
<img width="2140" height="1172" alt="cb6986ff9b391e2049a6c657f5d65324" src="https://github.com/user-attachments/assets/6d518ad3-d1fa-4671-8c0b-4341b0b3a709" />

### Checklist
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A patch changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
- [x] I have reviewed this pull request (self-review)