### PR TITLE
Upgrade to AI SDK 6

### DIFF
--- a/components/ai-elements/image.tsx
+++ b/components/ai-elements/image.tsx
@@ -1,7 +1,7 @@
-import type { Experimental_GeneratedImage } from "ai";
+import type { GeneratedFile } from "ai";
 import { cn } from "@/lib/utils";
 
-export type ImageProps = Experimental_GeneratedImage & {
+export type ImageProps = GeneratedFile & {
   className?: string;
   alt?: string;
 };

--- a/components/elements/image.tsx
+++ b/components/elements/image.tsx
@@ -1,7 +1,7 @@
-import type { Experimental_GeneratedImage } from "ai";
+import type { GeneratedFile } from "ai";
 import { cn } from "@/lib/utils";
 
-export type ImageProps = Experimental_GeneratedImage & {
+export type ImageProps = GeneratedFile & {
   className?: string;
   alt?: string;
 };

--- a/lib/ai/models.test.ts
+++ b/lib/ai/models.test.ts
@@ -9,7 +9,7 @@ const mockUsage = {
 
 export const chatModel = new MockLanguageModelV3({
   doGenerate: async () => ({
-    finishReason: "stop",
+    finishReason: { unified: "stop", raw: "stop" },
     usage: mockUsage,
     content: [{ type: "text", text: "Hello, world!" }],
     warnings: [],
@@ -25,7 +25,7 @@ export const chatModel = new MockLanguageModelV3({
 
 export const reasoningModel = new MockLanguageModelV3({
   doGenerate: async () => ({
-    finishReason: "stop",
+    finishReason: { unified: "stop", raw: "stop" },
     usage: mockUsage,
     content: [{ type: "text", text: "Hello, world!" }],
     warnings: [],
@@ -41,7 +41,7 @@ export const reasoningModel = new MockLanguageModelV3({
 
 export const titleModel = new MockLanguageModelV3({
   doGenerate: async () => ({
-    finishReason: "stop",
+    finishReason: { unified: "stop", raw: "stop" },
     usage: mockUsage,
     content: [{ type: "text", text: "This is a test title" }],
     warnings: [],
@@ -56,7 +56,7 @@ export const titleModel = new MockLanguageModelV3({
         { id: "1", type: "text-end" },
         {
           type: "finish",
-          finishReason: "stop",
+          finishReason: { unified: "stop", raw: "stop" },
           usage: mockUsage,
         },
       ],
@@ -66,7 +66,7 @@ export const titleModel = new MockLanguageModelV3({
 
 export const artifactModel = new MockLanguageModelV3({
   doGenerate: async () => ({
-    finishReason: "stop",
+    finishReason: { unified: "stop", raw: "stop" },
     usage: mockUsage,
     content: [{ type: "text", text: "Hello, world!" }],
     warnings: [],

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "test": "export PLAYWRIGHT=True && pnpm exec playwright test"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "2.0.0-beta.85",
-    "@ai-sdk/provider": "3.0.0-beta.27",
-    "@ai-sdk/react": "3.0.0-beta.162",
+    "@ai-sdk/gateway": "3.0.0",
+    "@ai-sdk/provider": "3.0.0",
+    "@ai-sdk/react": "3.0.1",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-python": "^6.1.6",
     "@codemirror/state": "^6.5.0",
@@ -47,7 +47,7 @@
     "@vercel/functions": "^2.0.0",
     "@vercel/otel": "^1.12.0",
     "@xyflow/react": "^12.10.0",
-    "ai": "6.0.0-beta.159",
+    "ai": "6.0.1",
     "bcrypt-ts": "^5.0.2",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@ai-sdk/gateway':
-        specifier: 2.0.0-beta.85
-        version: 2.0.0-beta.85(zod@3.25.76)
+        specifier: 3.0.0
+        version: 3.0.0(zod@3.25.76)
       '@ai-sdk/provider':
-        specifier: 3.0.0-beta.27
-        version: 3.0.0-beta.27
+        specifier: 3.0.0
+        version: 3.0.0
       '@ai-sdk/react':
-        specifier: 3.0.0-beta.162
-        version: 3.0.0-beta.162(react@19.0.1)(zod@3.25.76)
+        specifier: 3.0.1
+        version: 3.0.1(react@19.0.1)(zod@3.25.76)
       '@codemirror/lang-javascript':
         specifier: ^6.2.2
         version: 6.2.3
@@ -96,8 +96,8 @@ importers:
         specifier: ^12.10.0
         version: 12.10.0(@types/react@18.3.18)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
       ai:
-        specifier: 6.0.0-beta.159
-        version: 6.0.0-beta.159(zod@3.25.76)
+        specifier: 6.0.1
+        version: 6.0.1(zod@3.25.76)
       bcrypt-ts:
         specifier: ^5.0.2
         version: 5.0.3
@@ -303,24 +303,24 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@2.0.0-beta.85':
-    resolution: {integrity: sha512-1LFCTwweCe1KWyBR/v64zbvNJbAu4JPooa+0JVUclcb90RYQH2FDIQCbxN4H6J8is4yaTkHW5tbLNjHpOkxZuA==}
+  '@ai-sdk/gateway@3.0.0':
+    resolution: {integrity: sha512-JcjePYVpbezv+XOxkxPemwnorjWpgDiiKWMYy6FXTCG2rFABIK2Co1bFxIUSDT4vYO6f1448x9rKbn38vbhDiA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.0-beta.53':
-    resolution: {integrity: sha512-83/aNTnKfurb4jdaOSfh1KgxY27SuWZbecc3bUfiUxLMtAMBLusgWMaaSbfl2VHufAoGLXIuRYRq4lXlNCdXzw==}
+  '@ai-sdk/provider-utils@4.0.0':
+    resolution: {integrity: sha512-HyCyOls9I3a3e38+gtvOJOEjuw9KRcvbBnCL5GBuSmJvS9Jh9v3fz7pRC6ha1EUo/ZH1zwvLWYXBMtic8MTguA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.0-beta.27':
-    resolution: {integrity: sha512-g/H1lyBQa5TAolD0t9uW552z0dwo2evMPxE9gu22zkEUvQSkOl8F1C0Jg31sUPTn9xmKnDK+hjWsAsZnOFE9mQ==}
+  '@ai-sdk/provider@3.0.0':
+    resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@3.0.0-beta.162':
-    resolution: {integrity: sha512-vgJPUbHJ+y5Ebs1KmCnnjdebP7dsgW4uBEtPvmJJv/5JW7K4nizEFVOoxb2FF/mU7KbbE8qiprnM/XPRgC/znQ==}
+  '@ai-sdk/react@3.0.1':
+    resolution: {integrity: sha512-XUPDMFgalNtqBQg+Q3UiiEmWE3PC5pAoc+Drs5Z1Mxqe57za+hKCEwViYADuqeZrc0q6PXTzbcFlQb3pjyGjcQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
@@ -2575,8 +2575,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@6.0.0-beta.159:
-    resolution: {integrity: sha512-iwyz0iycu0Tu1of9GLGwiXvNgW6dB+hnFE0dzWubTQFKz0C8nB8gjMwRTiNhNXO6HuN9+uokg9DO7HYM2CRExw==}
+  ai@6.0.1:
+    resolution: {integrity: sha512-g/jPakC6h4vUJKDww0d6+VaJmfMC38UqH3kKsngiP+coT0uvCUdQ7lpFDJ0mNmamaOyRMaY2zwEB2RnTAaJU/w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4530,28 +4530,28 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@2.0.0-beta.85(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.0(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.0-beta.27
-      '@ai-sdk/provider-utils': 4.0.0-beta.53(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@3.25.76)
       '@vercel/oidc': 3.0.5
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.0-beta.53(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.0(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 3.0.0-beta.27
+      '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider@3.0.0-beta.27':
+  '@ai-sdk/provider@3.0.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.0-beta.162(react@19.0.1)(zod@3.25.76)':
+  '@ai-sdk/react@3.0.1(react@19.0.1)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.0-beta.53(zod@3.25.76)
-      ai: 6.0.0-beta.159(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.0(zod@3.25.76)
+      ai: 6.0.1(zod@3.25.76)
       react: 19.0.1
       swr: 2.3.3(react@19.0.1)
       throttleit: 2.1.0
@@ -6572,11 +6572,11 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ai@6.0.0-beta.159(zod@3.25.76):
+  ai@6.0.1(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 2.0.0-beta.85(zod@3.25.76)
-      '@ai-sdk/provider': 3.0.0-beta.27
-      '@ai-sdk/provider-utils': 4.0.0-beta.53(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.0(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 

--- a/tests/prompts/utils.ts
+++ b/tests/prompts/utils.ts
@@ -23,7 +23,7 @@ export function getResponseChunksByPrompt(
     { type: "text-start", id: "t1" },
     { type: "text-delta", id: "t1", delta: "Hello, world!" },
     { type: "text-end", id: "t1" },
-    { type: "finish", finishReason: "stop", usage: mockUsage }
+    { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: mockUsage }
   );
 
   return chunks;


### PR DESCRIPTION
## Summary
Upgrades the project to AI SDK 6 stable release with all breaking changes resolved.

## Changes
### Dependencies Updated
- `ai`: 6.0.0-beta.159 → **6.0.1** (stable)
- `@ai-sdk/react`: 3.0.0-beta.162 → **3.0.1** (stable)
- `@ai-sdk/gateway`: 2.0.0-beta.85 → **3.0.0** (stable)
- `@ai-sdk/provider`: 3.0.0-beta.27 → **3.0.0** (stable)

### Breaking Changes Resolved
1. **LanguageModelV3FinishReason Type Change**
   - Updated from simple string to structured object with `unified` and `raw` properties
   - Fixed in [lib/ai/models.test.ts](https://github.com/vercel/ai-chatbot/blob/upgrade-ai-sdk-6/lib/ai/models.test.ts) and [tests/prompts/utils.ts](https://github.com/vercel/ai-chatbot/blob/upgrade-ai-sdk-6/tests/prompts/utils.ts)

2. **Type Renames**
   - Renamed `Experimental_GeneratedImage` to `GeneratedFile` (now stable)
   - Updated in [components/ai-elements/image.tsx](https://github.com/vercel/ai-chatbot/blob/upgrade-ai-sdk-6/components/ai-elements/image.tsx) and [components/elements/image.tsx](https://github.com/vercel/ai-chatbot/blob/upgrade-ai-sdk-6/components/elements/image.tsx)

Fixes #1366