### PR TITLE
feat: add manual chat title rename functionality

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -8,6 +8,7 @@ import { getTitleModel } from "@/lib/ai/providers";
 import {
   deleteMessagesByChatIdAfterTimestamp,
   getMessageById,
+  updateChatTitleById,
   updateChatVisibilityById,
 } from "@/lib/db/queries";
 import { getTextFromMessage } from "@/lib/utils";
@@ -48,4 +49,14 @@ export async function updateChatVisibility({
   visibility: VisibilityType;
 }) {
   await updateChatVisibilityById({ chatId, visibility });
+}
+
+export async function updateChatTitle({
+  chatId,
+  title,
+}: {
+  chatId: string;
+  title: string;
+}) {
+  await updateChatTitleById({ chatId, title });
 }

--- a/components/sidebar-history-item.tsx
+++ b/components/sidebar-history-item.tsx
@@ -7,6 +7,7 @@ import {
   GlobeIcon,
   LockIcon,
   MoreHorizontalIcon,
+  PencilEditIcon,
   ShareIcon,
   TrashIcon,
 } from "./icons";
@@ -30,11 +31,13 @@ const PureChatItem = ({
   chat,
   isActive,
   onDelete,
+  onRename,
   setOpenMobile,
 }: {
   chat: Chat;
   isActive: boolean;
   onDelete: (chatId: string) => void;
+  onRename: (chatId: string, currentTitle: string) => void;
   setOpenMobile: (open: boolean) => void;
 }) => {
   const { visibilityType, setVisibilityType } = useChatVisibility({
@@ -62,6 +65,14 @@ const PureChatItem = ({
         </DropdownMenuTrigger>
 
         <DropdownMenuContent align="end" side="bottom">
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onSelect={() => onRename(chat.id, chat.title)}
+          >
+            <PencilEditIcon />
+            <span>Rename</span>
+          </DropdownMenuItem>
+
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="cursor-pointer">
               <ShareIcon />
@@ -114,6 +125,9 @@ const PureChatItem = ({
 
 export const ChatItem = memo(PureChatItem, (prevProps, nextProps) => {
   if (prevProps.isActive !== nextProps.isActive) {
+    return false;
+  }
+  if (prevProps.chat.title !== nextProps.chat.title) {
     return false;
   }
   return true;

--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -7,6 +7,7 @@ import type { User } from "next-auth";
 import { useState } from "react";
 import { toast } from "sonner";
 import useSWRInfinite from "swr/infinite";
+import { updateChatTitle } from "@/app/(chat)/actions";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,6 +18,16 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -116,6 +127,10 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
+  const [renameId, setRenameId] = useState<string | null>(null);
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+
   const hasReachedEnd = paginatedChatHistories
     ? paginatedChatHistories.some((page) => page.hasMore === false)
     : false;
@@ -157,6 +172,32 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
       },
       error: "Failed to delete chat",
     });
+  };
+
+  const handleRename = () => {
+    if (!renameId || !newTitle.trim()) {
+      setShowRenameDialog(false);
+      return;
+    }
+
+    const trimmedTitle = newTitle.trim();
+    setShowRenameDialog(false);
+
+    mutate(
+      (chatHistories) => {
+        if (chatHistories) {
+          return chatHistories.map((chatHistory) => ({
+            ...chatHistory,
+            chats: chatHistory.chats.map((chat) =>
+              chat.id === renameId ? { ...chat, title: trimmedTitle } : chat
+            ),
+          }));
+        }
+      },
+      { revalidate: false }
+    );
+
+    updateChatTitle({ chatId: renameId, title: trimmedTitle });
   };
 
   if (!user) {
@@ -241,6 +282,11 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setDeleteId(chatId);
                               setShowDeleteDialog(true);
                             }}
+                            onRename={(chatId, currentTitle) => {
+                              setRenameId(chatId);
+                              setNewTitle(currentTitle);
+                              setShowRenameDialog(true);
+                            }}
                             setOpenMobile={setOpenMobile}
                           />
                         ))}
@@ -260,6 +306,11 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                             onDelete={(chatId) => {
                               setDeleteId(chatId);
                               setShowDeleteDialog(true);
+                            }}
+                            onRename={(chatId, currentTitle) => {
+                              setRenameId(chatId);
+                              setNewTitle(currentTitle);
+                              setShowRenameDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
                           />
@@ -281,6 +332,11 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setDeleteId(chatId);
                               setShowDeleteDialog(true);
                             }}
+                            onRename={(chatId, currentTitle) => {
+                              setRenameId(chatId);
+                              setNewTitle(currentTitle);
+                              setShowRenameDialog(true);
+                            }}
                             setOpenMobile={setOpenMobile}
                           />
                         ))}
@@ -301,6 +357,11 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setDeleteId(chatId);
                               setShowDeleteDialog(true);
                             }}
+                            onRename={(chatId, currentTitle) => {
+                              setRenameId(chatId);
+                              setNewTitle(currentTitle);
+                              setShowRenameDialog(true);
+                            }}
                             setOpenMobile={setOpenMobile}
                           />
                         ))}
@@ -320,6 +381,11 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                             onDelete={(chatId) => {
                               setDeleteId(chatId);
                               setShowDeleteDialog(true);
+                            }}
+                            onRename={(chatId, currentTitle) => {
+                              setRenameId(chatId);
+                              setNewTitle(currentTitle);
+                              setShowRenameDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
                           />
@@ -371,6 +437,39 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <Dialog onOpenChange={setShowRenameDialog} open={showRenameDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename chat</DialogTitle>
+            <DialogDescription>
+              Enter a new name for this chat.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            placeholder="Chat title"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                handleRename();
+              }
+            }}
+          />
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setShowRenameDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleRename}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
This PR adds the ability for users to manually rename their chat titles from the sidebar.

## Demo
https://github.com/user-attachments/assets/400c222c-cdff-4e21-972f-b30d98c7d8a5

