### PR TITLE
chore: remove last message on stream error

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -86,6 +86,7 @@ export function Chat({
     regenerate,
     resumeStream,
     addToolApprovalResponse,
+    error
   } = useChat<ChatMessage>({
     id,
     messages: initialMessages,
@@ -223,6 +224,7 @@ export function Chat({
               setMessages={setMessages}
               status={status}
               stop={stop}
+              error={error}
             />
           )}
         </div>

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -68,6 +68,7 @@ function PureMultimodalInput({
   selectedVisibilityType,
   selectedModelId,
   onModelChange,
+  error
 }: {
   chatId: string;
   input: string;
@@ -83,6 +84,7 @@ function PureMultimodalInput({
   selectedVisibilityType: VisibilityType;
   selectedModelId: string;
   onModelChange?: (modelId: string) => void;
+  error?:UseChatHelpers<ChatMessage>["error"];
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
@@ -147,6 +149,10 @@ function PureMultimodalInput({
   const submitForm = useCallback(() => {
     window.history.pushState({}, "", `/chat/${chatId}`);
 
+    //https://ai-sdk.dev/docs/ai-sdk-ui/error-handling#alternative-replace-last-message
+    if(error){
+      setMessages(prev => prev.slice(0, -1)); // remove last message    
+    }
     sendMessage({
       role: "user",
       parts: [


### PR DESCRIPTION
removing the last message in case of error will help in not showing empty messages (as shown in the screenshot.) 

<img width="1920" height="1035" alt="image" src="https://github.com/user-attachments/assets/dd3087bb-5b28-4381-9619-215a59d16f3a" />
