### PR TITLE
Fix wrong project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="http://chatbot.ai-sdk.dev/">
+<a href="https://chatbot.ai-sdk.dev/">
   <img alt="Next.js 14 and App Router-ready Chatbot." src="app/(chat)/opengraph-image.png">
   <h1 align="center">Chatbot</h1>
 </a>
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="http://chatbot.ai-sdk.dev/"><strong>Read Docs</strong></a> ·
+  <a href="https://chatbot.ai-sdk.dev/"><strong>Read Docs</strong></a> ·
   <a href="#features"><strong>Features</strong></a> ·
   <a href="#model-providers"><strong>Model Providers</strong></a> ·
   <a href="#deploy-your-own"><strong>Deploy Your Own</strong></a> ·

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://chat.vercel.ai/">
+<a href="http://chatbot.ai-sdk.dev/">
   <img alt="Next.js 14 and App Router-ready Chatbot." src="app/(chat)/opengraph-image.png">
   <h1 align="center">Chatbot</h1>
 </a>
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://chatbot.dev"><strong>Read Docs</strong></a> ·
+  <a href="http://chatbot.ai-sdk.dev/"><strong>Read Docs</strong></a> ·
   <a href="#features"><strong>Features</strong></a> ·
   <a href="#model-providers"><strong>Model Providers</strong></a> ·
   <a href="#deploy-your-own"><strong>Deploy Your Own</strong></a> ·


### PR DESCRIPTION
The links to the project homepage are incorrect since the project rename.