### PR TITLE
fix: match MultimodalInput background to artifact panel

### DIFF
--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -337,7 +337,7 @@ function PureArtifact({
                   <MultimodalInput
                     attachments={attachments}
                     chatId={chatId}
-                    className="bg-background dark:bg-muted"
+                    className="bg-muted dark:bg-background"
                     input={input}
                     messages={messages}
                     selectedModelId={selectedModelId}


### PR DESCRIPTION
## Summary
                                                                                                         
  - Fixes a visual bug where the `MultimodalInput` wrapper in the artifact panel shows a sharp-cornered
  rectangle behind the rounded input form in both light and dark mode                                    
                                                                                                         
  ## Problem

  The artifact panel (`motion.div`, line 303) uses `bg-muted dark:bg-background`, but the
  `MultimodalInput` wrapper (line 340) uses the inverse: `bg-background dark:bg-muted`.

  Since the wrapper `div` has no `border-radius`, it's visible as a sharp rectangle behind the form's
  `rounded-xl` corners:
  - **Light mode:** white rectangle against the muted gray panel
  - **Dark mode:** lighter gray rectangle against the dark panel

  ## Screenshots

  **Before (bug)**

  <img src="https://github.com/user-attachments/assets/df12da86-173b-4ac0-a9ca-23415ea1d36f" width="500" 
  />

  **After (fix)**

  <img src="https://github.com/user-attachments/assets/7fbdbe99-96dd-42c1-8182-9b6e4aacd935" width="500" 
  />

  ## Fix

  Align the `MultimodalInput` className to match the parent panel's background:

  ```diff
  - className="bg-background dark:bg-muted"
  + className="bg-muted dark:bg-background"

  Test plan

  - Open an artifact (e.g. code generation) so the side panel appears
  - Verify no sharp-cornered rectangle around the chat input in light mode
  - Switch to dark mode and verify the same

  Removed the `alt` and `height` attributes — sometimes those cause rendering issues on GitHub. Just
  `src` and `width` is the most reliable.