### PR TITLE
fix(proxy): allow anonymous users to visit login and register

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,4 +1,3 @@
-import { getSessionCookie } from "better-auth/cookies";
 import { type NextRequest, NextResponse } from "next/server";
 
 export function proxy(request: NextRequest) {
@@ -14,14 +13,6 @@ export function proxy(request: NextRequest) {
 
   if (pathname.startsWith("/api/auth")) {
     return NextResponse.next();
-  }
-
-  const sessionCookie = getSessionCookie(request);
-
-  if (sessionCookie && ["/login", "/register"].includes(pathname)) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/";
-    return NextResponse.redirect(url);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## summary
- remove session cookie redirect from proxy for login/register pages
- anonymous users can now visit /login and /register to upgrade their account