### PR TITLE
fix(blob): switch to private access with auth-gated delivery route

### DIFF
--- a/app/(chat)/api/files/serve/route.ts
+++ b/app/(chat)/api/files/serve/route.ts
@@ -1,0 +1,46 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { get } from "@vercel/blob";
+
+import { auth } from "@/app/(auth)/auth";
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const pathname = request.nextUrl.searchParams.get("pathname");
+
+  if (!pathname) {
+    return NextResponse.json({ error: "Missing pathname" }, { status: 400 });
+  }
+
+  const result = await get(pathname, {
+    access: "private",
+    ifNoneMatch: request.headers.get("if-none-match") ?? undefined,
+  });
+
+  if (!result) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  if (result.statusCode === 304) {
+    return new NextResponse(null, {
+      status: 304,
+      headers: {
+        ETag: result.blob.etag,
+        "Cache-Control": "private, no-cache",
+      },
+    });
+  }
+
+  return new NextResponse(result.stream, {
+    headers: {
+      "Content-Type": result.blob.contentType,
+      "X-Content-Type-Options": "nosniff",
+      ETag: result.blob.etag,
+      "Cache-Control": "private, no-cache",
+    },
+  });
+}

--- a/app/(chat)/api/files/upload/route.ts
+++ b/app/(chat)/api/files/upload/route.ts
@@ -50,10 +50,14 @@ export async function POST(request: Request) {
 
     try {
       const data = await put(`${safeName}`, fileBuffer, {
-        access: "public",
+        access: "private",
       });
 
-      return NextResponse.json(data);
+      return NextResponse.json({
+        url: `/api/files/serve?pathname=${encodeURIComponent(data.pathname)}`,
+        pathname: data.pathname,
+        contentType: data.contentType,
+      });
     } catch (_error) {
       return NextResponse.json({ error: "Upload failed" }, { status: 500 });
     }

--- a/next.config.ts
+++ b/next.config.ts
@@ -36,10 +36,6 @@ const nextConfig: NextConfig = {
       {
         hostname: "avatar.vercel.sh",
       },
-      {
-        protocol: "https",
-        hostname: "*.public.blob.vercel-storage.com",
-      },
     ],
   },
   experimental: {

--- a/vercel-template.json
+++ b/vercel-template.json
@@ -13,7 +13,8 @@
       "integrationSlug": "upstash"
     },
     {
-      "type": "blob"
+      "type": "blob",
+      "access": "private"
     }
   ]
 }


### PR DESCRIPTION
## Summary

User-uploaded images are auth-gated content that should not be publicly accessible. This switches from public to private blob storage and adds a delivery route that checks the user's session before serving files.

**Changes:**
- Upload: `access: "public"` -> `access: "private"`, returns `/api/files/serve?pathname=...` instead of raw blob URL
- New `/api/files/serve` route: checks auth, streams private blob with ETag caching support
- Removed `*.public.blob.vercel-storage.com` from `next.config.ts` image patterns (no longer needed)

**No client changes needed** — the upload response interface (`{ url, pathname, contentType }`) is preserved, and `next/image` works with same-origin URLs without `remotePatterns`.

## Context

Aligns with the private-by-default direction for Vercel Blob (see vercel/front#65379, vercel/vercel#15375). The CLI now defaults to private-first prompts and requires explicit `--access` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)