### PR TITLE
fix: use optional chaining to fix lint errors

### DIFF
--- a/components/chat/artifact.tsx
+++ b/components/chat/artifact.tsx
@@ -162,7 +162,7 @@ function PureArtifact({
 
           const currentDocument = currentDocuments.at(-1);
 
-          if (!currentDocument || !currentDocument.content) {
+          if (!currentDocument?.content) {
             setIsContentDirty(false);
             return currentDocuments;
           }

--- a/lib/ai/tools/request-suggestions.ts
+++ b/lib/ai/tools/request-suggestions.ts
@@ -31,7 +31,7 @@ export const requestSuggestions = ({
     execute: async ({ documentId }) => {
       const document = await getDocumentById({ id: documentId });
 
-      if (!document || !document.content) {
+      if (!document?.content) {
         return {
           error: "Document not found",
         };

--- a/lib/editor/config.ts
+++ b/lib/editor/config.ts
@@ -30,7 +30,7 @@ export const handleTransaction = ({
   editorRef: MutableRefObject<EditorView | null>;
   onSaveContent: (updatedContent: string, debounce: boolean) => void;
 }) => {
-  if (!editorRef || !editorRef.current) {
+  if (!editorRef?.current) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Fix 3 pre-existing `lint/complexity/useOptionalChain` errors that have been failing CI on every PR.

- `components/chat/artifact.tsx:165` — `!doc || !doc.content` → `!doc?.content`
- `lib/ai/tools/request-suggestions.ts:34` — same pattern
- `lib/editor/config.ts:33` — `!ref || !ref.current` → `!ref?.current`

🤖 Generated with [Claude Code](https://claude.com/claude-code)