### PR TITLE
Fix #1466: Resumable Streams

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -32,6 +32,7 @@ import {
   getChatById,
   getMessageCountByUserId,
   getMessagesByChatId,
+  getStreamIdsByChatId,
   saveChat,
   saveMessages,
   updateChatTitleById,
@@ -56,6 +57,63 @@ function getStreamContext() {
 }
 
 export { getStreamContext };
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const chatId = searchParams.get("chatId");
+
+  if (!chatId) {
+    return new ChatbotError("bad_request:api").toResponse();
+  }
+
+  const session = await auth();
+
+  if (!session?.user) {
+    return new ChatbotError("unauthorized:chat").toResponse();
+  }
+
+  const chat = await getChatById({ id: chatId });
+
+  if (!chat) {
+    return new Response(null, { status: 204 });
+  }
+
+  if (chat.userId !== session.user.id) {
+    return new ChatbotError("forbidden:chat").toResponse();
+  }
+
+  const streamContext = getStreamContext();
+
+  if (!streamContext) {
+    return new Response(null, { status: 204 });
+  }
+
+  const streamIds = await getStreamIdsByChatId({ chatId });
+
+  if (!streamIds.length) {
+    return new Response(null, { status: 204 });
+  }
+
+  const recentStreamId = streamIds.at(-1);
+
+  if (!recentStreamId) {
+    return new Response(null, { status: 204 });
+  }
+
+  const emptyStream = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+
+  return new Response(
+    await streamContext.resumeExistingStream(recentStreamId, emptyStream),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }
+  );
+}
 
 export async function POST(request: Request) {
   let requestBody: PostRequestBody;

--- a/tests/e2e/api.test.ts
+++ b/tests/e2e/api.test.ts
@@ -76,6 +76,22 @@ test.describe("Chat Error Handling", () => {
   });
 });
 
+test.describe("Resumable Streams", () => {
+  test("GET /api/chat returns 400 when chatId is missing", async ({
+    request,
+  }) => {
+    const response = await request.get("/api/chat");
+    expect(response.status()).toBe(400);
+  });
+
+  test("GET /api/chat returns 401 when not authenticated", async ({
+    request,
+  }) => {
+    const response = await request.get("/api/chat?chatId=nonexistent");
+    expect(response.status()).toBe(401);
+  });
+});
+
 test.describe("Suggested Actions", () => {
   test("suggested actions are clickable", async ({ page }) => {
     await page.goto("/");


### PR DESCRIPTION
Closes #1466

## Before

When a user reloaded mid-stream, the browser called `GET /api/chat?chatId=...` to resume the stream. That route did not exist — the file `app/(chat)/api/chat/route.ts` only exported a `POST` handler. The missing route caused the request to fall through with a `204 No Content` response, leaving the UI in a broken loading state with no stream data replayed.

## After

`GET /api/chat` is now implemented and handles stream resumption end-to-end:

1. Returns `400` if `chatId` is absent from query params.
2. Returns `401` if the request is unauthenticated.
3. Returns `403` if the authenticated user does not own the chat.
4. Returns `204` if no chat, no stream context, or no recorded stream IDs are found (graceful no-op).
5. Otherwise, fetches the most recent stream ID via `getStreamIdsByChatId({ chatId })`, calls `streamContext.resumeExistingStream(recentStreamId, emptyStream)`, and returns the result as a `text/event-stream` response with status `200`.

## Changes

- **`app/(chat)/api/chat/route.ts`**: Added `GET` export implementing the resumable stream logic described above. Added `getStreamIdsByChatId` to the import list from the DB layer. An `emptyStream` (`ReadableStream` that closes immediately) is passed as the fallback to `resumeExistingStream` so the response is well-formed even when the original stream has already ended.
- **`tests/e2e/api.test.ts`**: Added a `"Resumable Streams"` test suite with two unauthenticated cases — `GET /api/chat` with no `chatId` expects `400`, and `GET /api/chat?chatId=nonexistent` without a session expects `401` — covering the input validation and auth guard paths.

## Testing

E2E tests added in `tests/e2e/api.test.ts` verify the error paths directly against the running server:

```
✓ GET /api/chat returns 400 when chatId is missing
✓ GET /api/chat returns 401 when not authenticated
```

Manual verification: reloading the page mid-stream now replays buffered SSE events rather than rendering the broken empty-state shown in the issue screenshot.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*