### PR TITLE
fix: tool approval deny flow breaks subsequent messages

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -186,7 +186,37 @@ export async function POST(request: Request) {
     const isReasoningModel = capabilities?.reasoning === true;
     const supportsTools = capabilities?.tools === true;
 
-    const modelMessages = await convertToModelMessages(uiMessages);
+    // Clean up unhandled tool approvals: strip pending parts from model context and mark them as denied in DB
+    const isPendingApproval = (part: Record<string, unknown>) =>
+      part.state === "approval-requested";
+
+    const cleanedMessages = uiMessages
+      .map((msg) => {
+        if (msg.role !== "assistant") return msg;
+        const cleanedParts = msg.parts.filter(
+          (part) => !isPendingApproval(part as Record<string, unknown>),
+        );
+        if (cleanedParts.length === msg.parts.length) return msg;
+        return { ...msg, parts: cleanedParts };
+      })
+      .filter((msg) => msg.role !== "assistant" || msg.parts.length > 0);
+
+
+    // Sync changes to the database
+    await Promise.all(
+      messagesFromDb.map(async (dbMsg) => {
+        const parts = dbMsg.parts as Record<string, unknown>[];
+        if (!parts.some(isPendingApproval)) return;
+        await updateMessage({
+          id: dbMsg.id,
+          parts: parts.map((p) =>
+            isPendingApproval(p) ? { ...p, state: "output-denied" } : p,
+          ) as DBMessage["parts"],
+        });
+      }),
+    );
+
+    const modelMessages = await convertToModelMessages(cleanedMessages);
 
     const stream = createUIMessageStream({
       originalMessages: isToolApprovalFlow ? uiMessages : undefined,

--- a/hooks/use-active-chat.tsx
+++ b/hooks/use-active-chat.tsx
@@ -6,6 +6,7 @@ import { DefaultChatTransport } from "ai";
 import { usePathname } from "next/navigation";
 import {
   createContext,
+  useCallback,
   type Dispatch,
   type ReactNode,
   type SetStateAction,
@@ -243,12 +244,47 @@ export function ActiveChatProvider({ children }: { children: ReactNode }) {
     { revalidateOnFocus: false }
   );
 
+  // Automatically change all messages still in the 'approval-requested' state to 'output-denied' when sending a new message.
+  // Ensure the user can continue chatting even without explicit approval (neither 'Allow' nor 'Deny').
+  const wrappedSendMessage: typeof sendMessage = useCallback(
+    (...args) => {
+      setMessages((prev) =>
+        prev.map((msg) => {
+          if (msg.role !== "assistant") return msg;
+
+          const hasPending = msg.parts.some(
+            (part) =>
+              "state" in part &&
+              (part as Record<string, unknown>).state === "approval-requested",
+          );
+          if (!hasPending) return msg;
+
+          return {
+            ...msg,
+            parts: msg.parts.map((part) => {
+              if (
+                "state" in part &&
+                (part as Record<string, unknown>).state === "approval-requested"
+              ) {
+                return { ...part, state: "output-denied" } as typeof part;
+              }
+              return part;
+            }),
+          };
+        }),
+      );
+
+      return sendMessage(...args);
+    },
+    [sendMessage, setMessages],
+  );
+
   const value = useMemo<ActiveChatContextValue>(
     () => ({
       chatId,
       messages,
       setMessages,
-      sendMessage,
+      sendMessage: wrappedSendMessage,
       status,
       stop,
       regenerate,
@@ -268,7 +304,7 @@ export function ActiveChatProvider({ children }: { children: ReactNode }) {
       chatId,
       messages,
       setMessages,
-      sendMessage,
+      wrappedSendMessage,
       status,
       stop,
       regenerate,

--- a/hooks/use-active-chat.tsx
+++ b/hooks/use-active-chat.tsx
@@ -117,8 +117,7 @@ export function ActiveChatProvider({ children }: { children: ReactNode }) {
           (part) =>
             "state" in part &&
             part.state === "approval-responded" &&
-            "approval" in part &&
-            (part.approval as { approved?: boolean })?.approved === true
+            "approval" in part
         ) ?? false
       );
     },
@@ -128,7 +127,7 @@ export function ActiveChatProvider({ children }: { children: ReactNode }) {
       prepareSendMessagesRequest(request) {
         const lastMessage = request.messages.at(-1);
         const isToolApprovalContinuation =
-          lastMessage?.role !== "user" ||
+          lastMessage?.role !== "user" &&
           request.messages.some((msg) =>
             msg.parts?.some((part) => {
               const state = (part as { state?: string }).state;


### PR DESCRIPTION
# fix: tool approval deny flow breaks subsequent messages

Fixes two related bugs in the tool approval flow that cause user messages to be silently dropped after denying a tool call.

When a user denies a tool approval (e.g., clicks "Deny" on ``), two issues occur:

1. **The deny action never reaches the server** — `sendAutomaticallyWhen` only triggers when `approved === true`, so denials are silently swallowed on the client.

2. **All subsequent user messages are lost** — After a denial, any new message the user types is incorrectly treated as a tool approval continuation. The message is never sent to the model, never saved to the database, and disappears on page refresh.

### before fix bug

https://github.com/user-attachments/assets/7545f9ff-b859-4185-9479-270b831d5149

### After fix bug

https://github.com/user-attachments/assets/abf21c2b-3e21-41e3-a20e-a1c36d31dfd8

## Root Cause

### Issue 1: `sendAutomaticallyWhen` ignores denials

```diff
 sendAutomaticallyWhen: ({ messages: currentMessages }) => {
   const lastMessage = currentMessages.at(-1);
   return (
     lastMessage?.parts?.some(
       (part) =>
         "state" in part &&
         part.state === "approval-responded" &&
-        "approval" in part &&
-        (part.approval as { approved?: boolean })?.approved === true
+        "approval" in part
     ) ?? false
   );
 },
```

The `approved === true` check means only approvals trigger auto-send. Denials update the local state to `approval-responded` but never send a request to the server.

### Issue 2: `||` in `prepareSendMessagesRequest` corrupts subsequent requests

```diff
 const isToolApprovalContinuation =
-  lastMessage?.role !== "user" ||
+  lastMessage?.role !== "user" &&
   request.messages.some((msg) =>
     msg.parts?.some((part) => {
       const state = (part as { state?: string }).state;
       return (
         state === "approval-responded" || state === "output-denied"
       );
     })
   );
```

With `||`, the condition evaluates as:

- Condition A: `lastMessage?.role !== "user"` → `false` (it IS a user message)
- Condition B: `request.messages.some(...)` → `true` (history contains `approval-responded` from the earlier deny)
- `false || true = true` → **incorrectly enters approval mode**

This causes the request body to send `{ messages: allMessages }` instead of `{ message: lastMessage }`. The backend then enters the tool approval branch (`Boolean(messages) = true`), which only performs approval state merging and completely ignores the user's new message.
<img width="2608" height="1085" alt="image" src="https://github.com/user-attachments/assets/ad2614f3-ee23-4de6-b02f-c54e6e2fab20" />

**Result:** The user's message is never sent to the model, never persisted to the database, and the model only sees the old denial — responding with "user denied" repeatedly.

With `&&`, a new user message (`lastMessage.role === "user"`) always takes the normal path regardless of historical approval states, which is the correct behavior.

## Steps to Reproduce and video

1. Send a message that triggers a tool requiring approval (e.g., `decryptSkaKey`)
2. Click **Deny** on the approval prompt
4. Type a new message (e.g., "please try again")
5. **Observe:** The model responds with "user has denied the operation" instead of processing the new message
6. **Refresh the page:** The new message you typed has disappeared, but the AI's denial response remains

## Changes

- **`sendAutomaticallyWhen`**: Remove `approved === true` filter so denials also trigger a server request
- **`prepareSendMessagesRequest`**: Change `||` to `&&` so new user messages are never misclassified as tool approval continuations
