### PR TITLE
fix(chat): drop mistral models and harden title generation

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -244,9 +244,13 @@ export async function POST(request: Request) {
         );
 
         if (titlePromise) {
-          const title = await titlePromise;
-          dataStream.write({ type: "data-chat-title", data: title });
-          updateChatTitleById({ chatId: id, title });
+          try {
+            const title = await titlePromise;
+            dataStream.write({ type: "data-chat-title", data: title });
+            updateChatTitleById({ chatId: id, title });
+          } catch (_) {
+            /* non-fatal */
+          }
         }
       },
       generateId: generateUUID,

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,11 +1,11 @@
 export const DEFAULT_CHAT_MODEL = "moonshotai/kimi-k2.5";
 
 export const titleModel = {
-  id: "mistral/mistral-small",
-  name: "Mistral Small",
-  provider: "mistral",
+  id: "moonshotai/kimi-k2.5",
+  name: "Kimi K2.5",
+  provider: "moonshotai",
   description: "Fast model for title generation",
-  gatewayOrder: ["mistral"],
+  gatewayOrder: ["fireworks", "bedrock"],
 };
 
 export type ModelCapabilities = {
@@ -30,20 +30,6 @@ export const chatModels: ChatModel[] = [
     provider: "deepseek",
     description: "Fast and capable model with tool use",
     gatewayOrder: ["bedrock", "deepinfra"],
-  },
-  {
-    id: "mistral/codestral",
-    name: "Codestral",
-    provider: "mistral",
-    description: "Code-focused model with tool use",
-    gatewayOrder: ["mistral"],
-  },
-  {
-    id: "mistral/mistral-small",
-    name: "Mistral Small",
-    provider: "mistral",
-    description: "Fast vision model with tool use",
-    gatewayOrder: ["mistral"],
   },
   {
     id: "moonshotai/kimi-k2.5",


### PR DESCRIPTION
## summary
- switch title generation model to moonshotai/kimi-k2.5 with fireworks and bedrock gateway fallback
- remove mistral/codestral and mistral/mistral-small from curated chatModels so they appear in the locked group instead of as selectable options
- catch title generation failures inside the stream execute so they no longer abort the chat response