### PR TITLE
Disable Cache Components by default for chat shell

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,7 +21,6 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_BASE_PATH: basePath,
   },
-  cacheComponents: true,
   devIndicators: false,
   poweredByHeader: false,
   reactCompiler: true,
@@ -44,7 +43,6 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     prefetchInlining: true,
-    cachedNavigations: true,
     appNewScrollHandler: true,
     inlineCss: true,
     turbopackFileSystemCacheForDev: true,


### PR DESCRIPTION
Fixes #1501.

## Summary

This disables Cache Components / PPR by default for the chatbot template by removing:

- `cacheComponents: true`
- `experimental.cachedNavigations: true`

## Root cause

In Next.js 16, `cacheComponents: true` opts the app into Cache Components / Partial Prerendering behavior, and `experimental.cachedNavigations` depends on that mode. The chat shell reads request-time data such as `auth()` and `cookies()`, so enabling PPR by default can cause a deployment to serve the homepage as a raw `application/x-nextjs-pre-render` payload rather than normal HTML. In that failure mode the request returns HTTP 200, but the page renders internal pre-render payload text instead of the chat UI.

This PR intentionally does not migrate the whole app to Cache Components/PPR. That would require a broader audit of request-time data access, Suspense boundaries, and cache semantics. The safer default for the template is to keep these experimental/PPR-related knobs off unless an app owner opts in explicitly.

## Testing

- `pnpm check`

I also attempted `pnpm build` locally, but this Codex macOS environment cannot load the Next.js native SWC binary due to a local code-signing issue:

```text
Failed to load SWC binary for darwin/arm64
```

That failure happens while loading Next/SWC and is unrelated to this config diff.
