### PR TITLE
fix(lint): remove redundant `noUnnecessaryConditions` option

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -33,7 +33,6 @@
         "useConsistentTypeDefinitions": "off"
       },
       "nursery": {
-        "noUnnecessaryConditions": "off",
         "useSortedClasses": "off"
       },
       "complexity": {


### PR DESCRIPTION
Biome fails config parsing with
"Found an unknown key", breaking `ultracite check` both locally and in CI

The `nursery.noUnnecessaryConditions` override in biome.jsonc was redundant because ultracite's shared config does not enable that rule