### PR TITLE
fix: artifact panel never auto-opens on a fast stream

### DIFF
--- a/artifacts/code/client.tsx
+++ b/artifacts/code/client.tsx
@@ -251,17 +251,20 @@ export const codeArtifact = new Artifact<"code", Metadata>({
   kind: "code",
   onStreamPart: ({ streamPart, setArtifact }) => {
     if (streamPart.type === "data-codeDelta") {
-      setArtifact((draftArtifact) => ({
-        ...draftArtifact,
-        content: streamPart.data,
-        isVisible:
-          draftArtifact.status === "streaming" &&
-          draftArtifact.content.length > 300 &&
-          draftArtifact.content.length < 310
-            ? true
-            : draftArtifact.isVisible,
-        status: "streaming",
-      }));
+      setArtifact((draftArtifact) => {
+        const content = streamPart.data;
+        return {
+          ...draftArtifact,
+          content,
+          isVisible:
+            draftArtifact.status === "streaming" &&
+            draftArtifact.content.length <= 300 &&
+            content.length > 300
+              ? true
+              : draftArtifact.isVisible,
+          status: "streaming",
+        };
+      });
     }
   },
   toolbar: [

--- a/artifacts/text/client.tsx
+++ b/artifacts/text/client.tsx
@@ -134,17 +134,20 @@ export const textArtifact = new Artifact<"text", TextArtifactMetadata>({
     }
 
     if (streamPart.type === "data-textDelta") {
-      setArtifact((draftArtifact) => ({
-        ...draftArtifact,
-        content: draftArtifact.content + streamPart.data,
-        isVisible:
-          draftArtifact.status === "streaming" &&
-          draftArtifact.content.length > 400 &&
-          draftArtifact.content.length < 450
-            ? true
-            : draftArtifact.isVisible,
-        status: "streaming",
-      }));
+      setArtifact((draftArtifact) => {
+        const content = draftArtifact.content + streamPart.data;
+        return {
+          ...draftArtifact,
+          content,
+          isVisible:
+            draftArtifact.status === "streaming" &&
+            draftArtifact.content.length <= 400 &&
+            content.length > 400
+              ? true
+              : draftArtifact.isVisible,
+          status: "streaming",
+        };
+      });
     }
   },
   toolbar: [


### PR DESCRIPTION
The artifact panel is supposed to auto-open mid-stream once real content starts coming in. It basically never does.

It gates `isVisible` on a tiny length window (text `> 400 && < 450`, code `> 300 && < 310`) re-checked on each delta. But deltas come in chunks, not one char at a time, so the length jumps straight over the window in a single delta and the check never passes. You only ever hit it if the stream happens to arrive ~1 char at a time.

image and sheet artifacts don't have this, they just flip the panel visible on the first delta. it's only text and code that gate it behind the length window, so they're the two that silently never open.

Swapped the window for a latch on the crossing (`prev <= 400 && new > 400`). Opens the moment content goes past the threshold, once, and won't reopen if you close the panel (guessing that's what the upper bound was for).

Ran it in a container against the actual reducers, not a paraphrase:

```
text  current: realistic ~120-char deltas -> never opens | 1-char deltas -> opens
      fixed:   realistic                  -> opens once   | after you close it -> stays closed
code  current: realistic                  -> never opens | 1-char deltas -> opens
      fixed:   realistic                  -> opens once   | after you close it -> stays closed
```

This PR was AI-generated and human-curated. I verified the change against the code but didn't hand-write it.
